### PR TITLE
Added optional trim tier in order to window and presum raw waveforms

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -104,6 +104,19 @@ rule build_raw:
     shell:
         "{swenv} python3 -B {basedir}/scripts/build_raw.py --log {log} --configs {configs} {input} {output}"
 
+rule build_trim:
+    input:
+        get_pattern_tier_raw(setup)
+    output:
+        get_pattern_tier_trim(setup)
+    log:
+        get_pattern_log(setup, "tier_trim")
+    group: "tier-trim"
+    resources:
+        runtime=300
+    shell:
+        "{swenv} python3 -B {basedir}/scripts/build_trim.py --log {log} --configs {configs} {input} {output}"
+
 #This rule builds the tcm files each raw file
 rule build_tier_tcm:
     input:

--- a/scripts/build_trim.py
+++ b/scripts/build_trim.py
@@ -1,0 +1,43 @@
+import argparse, os, pathlib
+import logging
+
+import pygama
+from data_trimmer.data_trimmer import data_trimmer
+import numpy as np
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("input", help="input file", type=str)
+argparser.add_argument("output", help="output file", type=str)
+argparser.add_argument("--configs", help="config file", type=str)
+argparser.add_argument("--log", help="log file", type=str)
+args = argparser.parse_args()
+
+logging.basicConfig(level=logging.INFO, filename=args.log, filemode='w')
+
+# both trimmed files are sent to the same directory as of now
+pathlib.Path(os.path.dirname(args.output[0])).mkdir(parents=True, exist_ok=True)
+
+# TODO: move this to the actual config... and drop in the correct values for the processors s
+trim_config = '''
+{
+    "outputs" : [ "windowed", "presummed" ],
+    "processors" : {
+        "windowed": {
+            "function": "double_windower",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
+            "unit": "ADC"
+        },
+        
+        "presummed": {
+            "function": "presum",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "presummed(len(waveform)/4, 'f')"],
+            "unit": "ADC"
+        }
+    }
+ }
+'''
+
+# the order of the arguments is: input file, windowed, presummed, dsp_config
+data_trimmer(args.input, args.output[0], args.output[1], trim_config)

--- a/scripts/build_trim.py
+++ b/scripts/build_trim.py
@@ -15,7 +15,7 @@ args = argparser.parse_args()
 logging.basicConfig(level=logging.INFO, filename=args.log, filemode='w')
 
 # both trimmed files are sent to the same directory as of now
-pathlib.Path(os.path.dirname(args.output[0])).mkdir(parents=True, exist_ok=True)
+pathlib.Path(os.path.dirname(args.output)).mkdir(parents=True, exist_ok=True)
 
 # TODO: move this to the actual config... and drop in the correct values for the processors
 # Note: the window value is actually set in the data_trimmer.py script
@@ -34,4 +34,4 @@ trim_config = '''
 '''
 
 # the order of the arguments is: input file, windowed, presummed, dsp_config
-data_trimmer(args.input, args.output[0], args.output[1], trim_config)
+data_trimmer(args.input, args.output, trim_config)

--- a/scripts/build_trim.py
+++ b/scripts/build_trim.py
@@ -17,18 +17,12 @@ logging.basicConfig(level=logging.INFO, filename=args.log, filemode='w')
 # both trimmed files are sent to the same directory as of now
 pathlib.Path(os.path.dirname(args.output[0])).mkdir(parents=True, exist_ok=True)
 
-# TODO: move this to the actual config... and drop in the correct values for the processors s
+# TODO: move this to the actual config... and drop in the correct values for the processors
+# Note: the window value is actually set in the data_trimmer.py script
 trim_config = '''
 {
-    "outputs" : [ "windowed", "presummed" ],
-    "processors" : {
-        "windowed": {
-            "function": "double_windower",
-            "module": "pygama.dsp.processors",
-            "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
-            "unit": "ADC"
-        },
-        
+    "outputs" : ["presummed" ],
+    "processors" : {        
         "presummed": {
             "function": "presum",
             "module": "pygama.dsp.processors",

--- a/scripts/data_trimmer/data_trimmer.py
+++ b/scripts/data_trimmer/data_trimmer.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pygama.lgdo as lgdo
+import numpy as np
+from pygama.dsp.processing_chain import build_processing_chain as bpc
+import sys
+import matplotlib.pyplot as plt
+import time
+import json
+
+def data_trimmer(raw_file: str, windowed_file: str, presummed_file: str, dsp_config: str | dict) -> None:
+    """
+    Takes in a raw file, and returns two files, one containing the presummed waveform, and the other 
+    containing a windowed waveform.
+
+    Parameters 
+    ----------
+    raw_file
+        A raw lh5 file to window and presum
+    windowed_file
+        Name of an lh5 file that will contain windowed waveforms 
+    presummed_file
+        Name of an lh5 file that will contain presummed waveforms 
+    dsp_config 
+        Either the path to the dsp config file to use, or a dictionary of config
+    """
+    # In the future, put a build_processing_chain-esque dsp and write statement into the read_chunk() loop part of build_raw
+
+    # Read in the raw file
+    sto = lgdo.LH5Store()
+    lh5_tables = lgdo.ls(raw_file)
+
+    # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
+    for i, tb in enumerate(lh5_tables):
+        if "raw" not in tb and lgdo.ls(raw_file, f"{tb}/raw"):
+            lh5_tables[i] = f"{tb}/raw"
+        elif not lgdo.ls(raw_file, tb):
+            del lh5_tables[i]
+
+    if len(lh5_tables) == 0:
+        raise RuntimeError(f"could not find any valid LH5 table in {f_raw}")
+
+    # Grab the constants from the dsp config 
+    if isinstance(dsp_config, str) and dsp_config.endswith(".json"):
+        f = open(dsp_config)
+        dsp_dict = json.load(f)
+        f.close()
+    # If we get a string that is in the correct format as a json file
+    elif isinstance(dsp_config, str):
+        dsp_dict = json.loads(dsp_config)
+    # Or we could get a dict as the config
+    elif isinstance(dsp_config, dict):
+        dsp_dict = dsp_config
+
+
+    # Read in the presummed rate from the config file to modify the clock rate later 
+    presum_rate_string = dsp_dict["processors"]["presummed"]["args"][1]
+    presum_rate_start_idx = presum_rate_string.find("/")+1
+    presum_rate_end_idx = presum_rate_string.find(",")
+    presum_rate = int(presum_rate_string[presum_rate_start_idx:presum_rate_end_idx])
+
+    # Read in the start index from the config file so that we can change the t0 later 
+    window_start_index = int(dsp_dict["processors"]["windowed"]["args"][1])
+
+    # loop over the tables in the file, allows for the case of multiple channels per file 
+    for raw_group in lh5_tables:        
+        # Read in the table that we will modify
+        raw_table, _ = sto.read_object(raw_group, raw_file)
+       
+        # Execute the processing chain
+        proc_chain, mask, dsp_out = bpc(raw_table, dsp_dict)
+        proc_chain.execute()
+
+        # Retype the dsp output of the windowed waveform from float32 back down to uint16:
+        dsp_out["windowed"].nda = dsp_out["windowed"].nda.astype(np.uint16)
+
+        # Write the presummed waveform to file 
+        # Overwrite the waveform values with those from the processed waveform
+        raw_table["waveform"]["values"].nda = dsp_out["presummed"].nda
+
+        # For the presummed waveform, overwrite the dt:
+        raw_table["waveform"]["dt"].nda = np.full(len(raw_table["waveform"]["dt"]), raw_table["waveform"]["dt"].nda[0]*float(presum_rate)) # The clock rate should be the same across the file
+        
+        # Write to raw files
+        sto.write_object(raw_table, "raw", presummed_file, group=raw_group.split("/raw")[0], wo_mode="a")
+
+        # Write the windowed waveform to a file 
+        # Overwrite the waveform values with those from the processed waveform
+        raw_table["waveform"]["values"].nda =  dsp_out["windowed"].nda
+
+        # For the windowed waveform, change the t0 by the windowing (t0+start_index*dt?) or units of (t0/dt+start_index) in samples
+        raw_table["waveform"]["t0"].nda /= raw_table["waveform"]["dt"].nda * float(presum_rate) # undo the clock rate transform from the presummed wf
+        raw_table["waveform"]["t0"].nda += float(window_start_index)
+        raw_table["waveform"]["t0"].attrs['units'] = "samples" # Changed the units to samples
+
+        sto.write_object(raw_table, "raw", windowed_file, group=raw_group.split("/raw")[0], wo_mode="a")

--- a/scripts/data_trimmer/test_data_trimmer.py
+++ b/scripts/data_trimmer/test_data_trimmer.py
@@ -5,6 +5,7 @@ import pygama.lgdo as lgdo
 import numpy as np
 import json
 import os
+import sys
 
 from pygama.data_trimmer.data_trimmer import data_trimmer
 
@@ -18,10 +19,9 @@ def test_data_trimmer_packet_ids(lgnd_test_data):
     raw_file = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/raw/cal/p01/r014/l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5")
     dsp_config = f"{config_dir}/data_trimmer_config.json"
 
-    presummed_file = raw_file.replace("l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T104550Z-tier_raw_presummed.lh5")
-    windowed_file = raw_file.replace("l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T104550Z-tier_raw_windowed.lh5")
+    trimmed_file = raw_file.replace("l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T104550Z-tier_raw_trimmed.lh5")
 
-    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+    data_trimmer(raw_file, trimmed_file, dsp_config)
 
     lh5_tables = lgdo.ls(raw_file)
     # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
@@ -35,11 +35,9 @@ def test_data_trimmer_packet_ids(lgnd_test_data):
 
     for raw_group in lh5_tables: 
         raw_packet_ids = sto.read_object(str(raw_group) + "/packet_id", raw_file)
-        presummed_packet_ids = sto.read_object(str(raw_group) + "/packet_id", presummed_file)
-        windowed_packet_ids = sto.read_object(str(raw_group) + "/packet_id", windowed_file)
+        trimmed_packet_ids = sto.read_object(str(raw_group) + "/packet_id", trimmed_file)
 
-        assert np.array_equal(raw_packet_ids[0].nda, presummed_packet_ids[0].nda)
-        assert np.array_equal(raw_packet_ids[0].nda, windowed_packet_ids[0].nda)
+        assert np.array_equal(raw_packet_ids[0].nda, trimmed_packet_ids[0].nda)
 
 
 # check that packet indexes match in verification test 
@@ -47,24 +45,23 @@ def test_data_trimmer_waveform_lengths(lgnd_test_data):
 
     # Set up I/O files, including config 
     raw_file = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/raw/cal/p01/r014/l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5")
-    presummed_file = raw_file.replace("l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T105236Z-tier_raw_presummed.lh5")
-    windowed_file = raw_file.replace("l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T105236Z-tier_raw_windowed.lh5")
+    trimmed_file = raw_file.replace("l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T105236Z-tier_raw_trimmed.lh5")
 
     dsp_config = '''
     {
         "outputs" : [ "presummed" ],
         "processors" : {            
             "presummed": {
-                "function": "presum",
+                "function": "unnorm_presum",
                 "module": "pygama.dsp.processors",
-                "args": ["waveform", "presummed(len(waveform)/4, 'f')"],
+                "args": ["waveform", "presummed(len(waveform)/4, 'uint32')"],
                 "unit": "ADC"
             }
         }
     }
     '''
 
-    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+    data_trimmer(raw_file, trimmed_file, dsp_config)
 
     lh5_tables = lgdo.ls(raw_file)
     # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
@@ -101,22 +98,55 @@ def test_data_trimmer_waveform_lengths(lgnd_test_data):
     for raw_group in lh5_tables:
 
         raw_packet_waveform_values = sto.read_object(str(raw_group) + "/waveform/values", raw_file)
-        presummed_packet_waveform_values = sto.read_object(str(raw_group) +"/waveform/values", presummed_file)
-        windowed_packet_waveform_values = sto.read_object(str(raw_group) +"/waveform/values", windowed_file)
+        presummed_packet_waveform_values = sto.read_object(str(raw_group) +"/presummed_waveform/values", trimmed_file)
+        windowed_packet_waveform_values = sto.read_object(str(raw_group) +"/windowed_waveform/values", trimmed_file)
 
+        # Check that the lengths of the waveforms match what we expect
         assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate*len(presummed_packet_waveform_values[0].nda[0])
+        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
         assert len(raw_packet_waveform_values[0].nda[0]) == len(windowed_packet_waveform_values[0].nda[0])+window_start_index+window_end_index
+        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+
+        raw_packet_waveform_t0s, _ = sto.read_object(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts, _ = sto.read_object(str(raw_group) + "/waveform/dt", raw_file)
+
+        windowed_packet_waveform_t0s, _ = sto.read_object(str(raw_group) + "/windowed_waveform/t0", trimmed_file)
+        presummed_packet_waveform_t0s, _ = sto.read_object(str(raw_group) + "/presummed_waveform/t0", trimmed_file)
+
+        # Check that the t0s match what we expect, with the correct units 
+        assert raw_packet_waveform_t0s.nda[0] == (windowed_packet_waveform_t0s.nda[0]-window_start_index)*raw_packet_waveform_t0s.nda[0]
+        assert windowed_packet_waveform_t0s.attrs['units'] == "samples" 
+        assert raw_packet_waveform_t0s.nda[0] == presummed_packet_waveform_t0s.nda[0] 
+        assert presummed_packet_waveform_t0s.attrs['units'] == raw_packet_waveform_t0s.attrs['units'] 
+
+        presummed_packet_waveform_dts, _ = sto.read_object(str(raw_group) + "/presummed_waveform/dt", trimmed_file)
+
+        # Check that the dts match what we expect, with the correct units 
+        assert raw_packet_waveform_dts.nda[0] == presummed_packet_waveform_dts.nda[0] / presum_rate
+
 
 def test_data_trimmer_file_size_decrease(lgnd_test_data):
     # Set up I/O files, including config 
     raw_file = lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5")
     dsp_config = f"{config_dir}/data_trimmer_config.json"
 
-    presummed_file = raw_file.replace("LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5", "LDQTA_r117_20200110T105115Z_cal_geds_raw_presummed.lh5")
-    windowed_file = raw_file.replace("LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5", "LDQTA_r117_20200110T105115Z_cal_geds_raw_windowed.lh5")
+    trimmed_file = raw_file.replace("LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5", "LDQTA_r117_20200110T105115Z_cal_geds_raw_trimmed.lh5")
 
-    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+    data_trimmer(raw_file, trimmed_file, dsp_config)
 
-    assert os.path.getsize(presummed_file) < os.path.getsize(raw_file)
-    assert os.path.getsize(windowed_file) < os.path.getsize(raw_file)
+    lh5_tables = lgdo.ls(raw_file)
+    for i, tb in enumerate(lh5_tables):
+        if "raw" not in tb and lgdo.ls(raw_file, f"{tb}/raw"):
+            lh5_tables[i] = f"{tb}/raw"
+        elif not lgdo.ls(raw_file, tb):
+            del lh5_tables[i]
+    sto = lgdo.LH5Store()
+
+    wf_size = 0
+
+    for raw_group in lh5_tables:
+        wf_size +=  sys.getsizeof(sto.read_object(str(raw_group) + "/waveform/values", raw_file)[0].nda)
+
+    # Make sure we are taking up less space than a file that has two copies of the waveform table in it
+    assert os.path.getsize(trimmed_file) < os.path.getsize(raw_file)+wf_size 
 

--- a/scripts/data_trimmer/test_data_trimmer.py
+++ b/scripts/data_trimmer/test_data_trimmer.py
@@ -1,0 +1,129 @@
+import pytest
+from pathlib import Path
+
+import pygama.lgdo as lgdo
+import numpy as np
+import json
+import os
+
+from pygama.data_trimmer.data_trimmer import data_trimmer
+
+
+config_dir = Path(__file__).parent / "test_data_trimmer_configs"
+
+# check that packet indexes match in verification test 
+def test_data_trimmer_packet_ids(lgnd_test_data):
+
+    # Set up I/O files, including config 
+    raw_file = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/raw/cal/p01/r014/l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5")
+    dsp_config = f"{config_dir}/data_trimmer_config.json"
+
+    presummed_file = raw_file.replace("l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T104550Z-tier_raw_presummed.lh5")
+    windowed_file = raw_file.replace("l60-p01-r014-cal-20220716T104550Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T104550Z-tier_raw_windowed.lh5")
+
+    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+
+    lh5_tables = lgdo.ls(raw_file)
+    # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
+    for i, tb in enumerate(lh5_tables):
+        if "raw" not in tb and lgdo.ls(raw_file, f"{tb}/raw"):
+            lh5_tables[i] = f"{tb}/raw"
+        elif not lgdo.ls(raw_file, tb):
+            del lh5_tables[i]
+
+    sto = lgdo.LH5Store()
+
+    for raw_group in lh5_tables: 
+        raw_packet_ids = sto.read_object(str(raw_group) + "/packet_id", raw_file)
+        presummed_packet_ids = sto.read_object(str(raw_group) + "/packet_id", presummed_file)
+        windowed_packet_ids = sto.read_object(str(raw_group) + "/packet_id", windowed_file)
+
+        assert np.array_equal(raw_packet_ids[0].nda, presummed_packet_ids[0].nda)
+        assert np.array_equal(raw_packet_ids[0].nda, windowed_packet_ids[0].nda)
+
+
+# check that packet indexes match in verification test 
+def test_data_trimmer_waveform_lengths(lgnd_test_data):
+
+    # Set up I/O files, including config 
+    raw_file = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/raw/cal/p01/r014/l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5")
+    presummed_file = raw_file.replace("l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T105236Z-tier_raw_presummed.lh5")
+    windowed_file = raw_file.replace("l60-p01-r014-cal-20220716T105236Z-tier_raw.lh5", "l60-p01-r014-cal-20220716T105236Z-tier_raw_windowed.lh5")
+
+    dsp_config = '''
+    {
+        "outputs" : [ "windowed", "presummed" ],
+        "processors" : {
+            "windowed": {
+                "function": "double_windower",
+                "module": "pygama.dsp.processors",
+                "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
+                "unit": "ADC"
+            },
+            
+            "presummed": {
+                "function": "presum",
+                "module": "pygama.dsp.processors",
+                "args": ["waveform", "presummed(len(waveform)/4, 'f')"],
+                "unit": "ADC"
+            }
+        }
+    }
+    '''
+
+    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+
+    lh5_tables = lgdo.ls(raw_file)
+    # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
+    for i, tb in enumerate(lh5_tables):
+        if "raw" not in tb and lgdo.ls(raw_file, f"{tb}/raw"):
+            lh5_tables[i] = f"{tb}/raw"
+        elif not lgdo.ls(raw_file, tb):
+            del lh5_tables[i]
+
+    if isinstance(dsp_config, str) and dsp_config.endswith(".json"):
+        f = open(dsp_config)
+        jsonfile = json.load(f)
+        f.close()
+    # If we get a string that is in the correct format as a json file
+    elif isinstance(dsp_config, str):
+        jsonfile = json.loads(dsp_config)
+    # Or we could get a dict as the config
+    elif isinstance(dsp_config, dict):
+        jsonfile = dsp_config
+
+    # Read in the presummed rate from the config file to modify the clock rate later 
+    presum_rate_string = jsonfile["processors"]["presummed"]["args"][1]
+    presum_rate_start_idx = presum_rate_string.find("/")+1
+    presum_rate_end_idx = presum_rate_string.find(",")
+    presum_rate = int(presum_rate_string[presum_rate_start_idx:presum_rate_end_idx])
+
+    # Read in the start index from the config file so that we can change the t0 later 
+    window_start_index = int(jsonfile["processors"]["windowed"]["args"][1])
+    window_end_index = int(jsonfile["processors"]["windowed"]["args"][2])
+
+
+    sto = lgdo.LH5Store()
+
+    for raw_group in lh5_tables:
+
+        raw_packet_waveform_values = sto.read_object(str(raw_group) + "/waveform/values", raw_file)
+        presummed_packet_waveform_values = sto.read_object(str(raw_group) +"/waveform/values", presummed_file)
+        windowed_packet_waveform_values = sto.read_object(str(raw_group) +"/waveform/values", windowed_file)
+
+        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate*len(presummed_packet_waveform_values[0].nda[0])
+        assert len(raw_packet_waveform_values[0].nda[0]) == len(windowed_packet_waveform_values[0].nda[0])+window_start_index+window_end_index
+
+def test_data_trimmer_file_size_decrease(lgnd_test_data):
+    # Set up I/O files, including config 
+    raw_file = lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5")
+    dsp_config = f"{config_dir}/data_trimmer_config.json"
+
+    presummed_file = raw_file.replace("LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5", "LDQTA_r117_20200110T105115Z_cal_geds_raw_presummed.lh5")
+    windowed_file = raw_file.replace("LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5", "LDQTA_r117_20200110T105115Z_cal_geds_raw_windowed.lh5")
+
+    data_trimmer(raw_file, windowed_file, presummed_file, dsp_config)
+
+    assert os.path.getsize(presummed_file) < os.path.getsize(raw_file)
+    assert os.path.getsize(windowed_file) < os.path.getsize(raw_file)
+

--- a/scripts/data_trimmer/test_data_trimmer.py
+++ b/scripts/data_trimmer/test_data_trimmer.py
@@ -52,15 +52,8 @@ def test_data_trimmer_waveform_lengths(lgnd_test_data):
 
     dsp_config = '''
     {
-        "outputs" : [ "windowed", "presummed" ],
-        "processors" : {
-            "windowed": {
-                "function": "double_windower",
-                "module": "pygama.dsp.processors",
-                "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
-                "unit": "ADC"
-            },
-            
+        "outputs" : [ "presummed" ],
+        "processors" : {            
             "presummed": {
                 "function": "presum",
                 "module": "pygama.dsp.processors",
@@ -98,9 +91,9 @@ def test_data_trimmer_waveform_lengths(lgnd_test_data):
     presum_rate_end_idx = presum_rate_string.find(",")
     presum_rate = int(presum_rate_string[presum_rate_start_idx:presum_rate_end_idx])
 
-    # Read in the start index from the config file so that we can change the t0 later 
-    window_start_index = int(jsonfile["processors"]["windowed"]["args"][1])
-    window_end_index = int(jsonfile["processors"]["windowed"]["args"][2])
+    # This needs to be overwritten with the correct windowing values set in data_trimmer.py 
+    window_start_index = 1000
+    window_end_index = 1000
 
 
     sto = lgdo.LH5Store()

--- a/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
+++ b/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
@@ -2,9 +2,9 @@
     "outputs" : ["presummed"],
     "processors" : {        
         "presummed": {
-            "function": "presum",
+            "function": "unnorm_presum",
             "module": "pygama.dsp.processors",
-            "args": ["waveform", "presummed(len(waveform)/4, 'f')"],
+            "args": ["waveform", "presummed(len(waveform)/4, 'uint32')"],
             "unit": "ADC"
         }
     }

--- a/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
+++ b/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
@@ -1,13 +1,6 @@
 {
-    "outputs" : [ "windowed", "presummed" ],
-    "processors" : {
-        "windowed": {
-            "function": "double_windower",
-            "module": "pygama.dsp.processors",
-            "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
-            "unit": "ADC"
-        },
-        
+    "outputs" : ["presummed"],
+    "processors" : {        
         "presummed": {
             "function": "presum",
             "module": "pygama.dsp.processors",

--- a/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
+++ b/scripts/data_trimmer/test_data_trimmer_configs/data_trimmer_config.json
@@ -1,0 +1,18 @@
+{
+    "outputs" : [ "windowed", "presummed" ],
+    "processors" : {
+        "windowed": {
+            "function": "double_windower",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "1000", "1000", "windowed(len(waveform)-2000, 'f')"],
+            "unit": "ADC"
+        },
+        
+        "presummed": {
+            "function": "presum",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "presummed(len(waveform)/4, 'f')"],
+            "unit": "ADC"
+        }
+    }
+ }

--- a/scripts/util/patterns.py
+++ b/scripts/util/patterns.py
@@ -25,6 +25,9 @@ def get_pattern_tier_daq(setup):
 def get_pattern_tier_raw(setup):
     return os.path.join(f"{tier_raw_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw.lh5")
 
+def get_pattern_tier_trim(setup):
+    return os.path.join(f"{tier_trim_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw_windowed.lh5"), os.path.join(f"{tier_trim_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw_presummed.lh5") 
+
 def get_pattern_tier_tcm(setup):
     return os.path.join(f"{tier_tcm_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_tcm.lh5")
 
@@ -42,6 +45,8 @@ def get_pattern_tier(setup,tier):
         return get_pattern_tier_daq(setup)
     elif tier =="raw":
         return get_pattern_tier_raw(setup)
+    elif tier == "trim":
+        return get_pattern_tier_trim(setup)
     elif tier =="tcm":
         return get_pattern_tier_tcm(setup)
     elif tier =="dsp":
@@ -58,6 +63,12 @@ def get_pattern_par_raw(setup, name=None):
         return os.path.join(f"{par_raw_path(setup)}",  "cal", "{period}", "{run}", "{experiment}-{period}-{run}-cal-{timestamp}-par_raw_"+name+".json")
     else:
         return os.path.join(f"{par_raw_path(setup)}", "cal", "{period}", "{run}", "{experiment}-{period}-{run}-cal-{timestamp}-par_raw.json")
+
+def get_pattern_par_trim(setup, name=None):
+    if name is not None:
+        return os.path.join(f"{par_trim_path(setup)}",  "cal", "{period}", "{run}", "{experiment}-{period}-{run}-cal-{timestamp}-par_trim_"+name+".json")
+    else:
+        return os.path.join(f"{par_rim_path(setup)}", "cal", "{period}", "{run}", "{experiment}-{period}-{run}-cal-{timestamp}-par_trim.json")
 
 def get_pattern_par_tcm(setup, name=None):
     if name is not None:
@@ -89,6 +100,8 @@ def get_pattern_par_evt(setup, name=None):
 def get_pattern_pars(setup, tier, name = None):
     if tier =="raw":
         return get_pattern_par_raw(setup, name=name)
+    elif tier =="trim":
+        return get_pattern_par_trim(setup, name=name)
     elif tier =="tcm":
         return get_pattern_par_tcm(setup, name=name)
     elif tier =="dsp":

--- a/scripts/util/patterns.py
+++ b/scripts/util/patterns.py
@@ -26,7 +26,7 @@ def get_pattern_tier_raw(setup):
     return os.path.join(f"{tier_raw_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw.lh5")
 
 def get_pattern_tier_trim(setup):
-    return os.path.join(f"{tier_trim_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw_windowed.lh5"), os.path.join(f"{tier_trim_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw_presummed.lh5") 
+    return os.path.join(f"{tier_trim_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_raw_trimmed.lh5")
 
 def get_pattern_tier_tcm(setup):
     return os.path.join(f"{tier_tcm_path(setup)}", "{datatype}","{period}", "{run}", "{experiment}-{period}-{run}-{datatype}-{timestamp}-tier_tcm.lh5")


### PR DESCRIPTION
Because data trimming is separate from build_raw (for now...), I've decided to put the code that windows and presums the waveforms in this LEGEND-specific repo. The function `data_trimmer` works by running a processing chain containing windower and presum processors on the raw data. A unit test for `data_trimmer.py` is also included in case this piece of code ever eventually makes it to `pygama`, or if people want to test it out. `data_trimmer.py` relies on a new `double_windower.py` processor, which lives in this pull request https://github.com/legend-exp/pygama/pull/407

Apologies to @ggmarshall if the snakemake rules for this new trim tier aren't correct... I tried my best!