### PR TITLE
Add blinding script implementation

### DIFF
--- a/scripts/build_raw_blind.py
+++ b/scripts/build_raw_blind.py
@@ -2,7 +2,8 @@
 This script takes in raw data, applies the calibration to the daqenergy
 and uses this to blind the data in a window of Qbb +- 25 keV. It copies over all
 channels in a raw file, removing those events that fall within the ROI for Ge detectors
-that have a daqenergy calibration curve and are not anti-coincidence only (AC).
+that have a daqenergy calibration curve and are not anti-coincidence only (AC). It removes
+the whole event from all of the Ge and SiPM channels.
 
 In the Snakemake dataflow, this script only runs if the checkfile is found on disk,
 but this is controlled by the Snakemake flow (presumably an error is thrown if the file
@@ -42,49 +43,28 @@ ROI = 25.0  # keV
 # list of all channels and objects in the raw file
 all_channels = lh5.ls(args.input)
 
-# list of just germanium channels with associated metadata
-# I'm not sure if this is supposed to be "daq.fcid" or "daq.fc_channel"
-# (from a recent pull that renamed it) or "daq.rawid", which is what I've chosen for now
-chmap = LegendMetadata(path=args.chan_maps)
-ged_channels = (
-    chmap.channelmap(args.timestamp).map("system", unique=False)["geds"].map("daq.rawid")
-)
+# list of Ge channels and SiPM channels with associated metadata
+legendmetadata = LegendMetadata()
+ged_channels = legendmetadata.channelmap(args.timestamp).map("system", unique=False)["geds"].map("daq.rawid")
+spms_channels = legendmetadata.channelmap(args.timestamp).map("system", unique=False)["spms"].map("daq.rawid")
 
 store = lh5.LH5Store()
 
-for channel in all_channels:
-    try:
-        chnum = int(channel[2::])
-    except ValueError:
-        # if this isn't an interesting channel, just copy it to the output file
-        chobj, _ = store.read_object(channel, args.input)
-        store.write_object(chobj, channel, args.output, wo_mode="overwrite")
-        continue
+# rows that need blinding
+toblind = np.array([])
 
-    if chnum not in list(ged_channels):
-        # if this is a SiPM or Ge not included for some reason, just copy it to the output file
-        chobj, _ = store.read_object(channel + "/raw", args.input)
-        store.write_object(
-            chobj, group=channel, name="raw", lh5_file=args.output, wo_mode="overwrite"
-        )
-        continue
+# first, loop through the Ge detector channels, calibrate them and look for events that should be blinded
+for chnum in list(ged_channels):
 
-    if ged_channels[chnum]["analysis"]["usability"] == "ac":
-        # if this Ge is to be used for anti-coincidence only, it will not have a blinding calibration
-        # (or at least it should not be blinded) so just copy it to the output file
-        chobj, _ = store.read_object(channel + "/raw", args.input)
-        store.write_object(
-            chobj, group=channel, name="raw", lh5_file=args.output, wo_mode="overwrite"
-        )
+    # skip Ge detectors that are anti-coincidence only
+    if ged_channels[chnum]["analysis"]["usability"] == 'ac':
         continue
-
-    # the rest should be the Ge channels that need to be blinded
 
     # load in just the daqenergy for now
-    daqenergy, _ = store.read_object(channel + "/raw/daqenergy", args.input)
+    daqenergy, _ = store.read_object(f"ch{chnum}/raw/daqenergy", args.input)
 
     # read in calibration curve for this channel
-    blind_curve = Props.read_from(args.blind_curve)[channel]
+    blind_curve = Props.read_from(args.blind_curve)[f"ch{chnum}"]
 
     # calibrate daq energy using pre existing curve
     daqenergy_cal = ne.evaluate(
@@ -92,18 +72,37 @@ for channel in all_channels:
         local_dict=dict(daqenergy=daqenergy, **blind_curve["daqenergy_cal"]["parameters"]),
     )
 
-    # figure out which events should be kept unblinded
-    tokeep = np.nonzero(np.abs(np.asarray(daqenergy_cal) - Qbb) > ROI)[0]
+    # figure out which event indices should be blinded
+    toblind = np.append(toblind, np.nonzero(np.abs(np.asarray(daqenergy_cal) - Qbb) <= ROI)[0])  
+
+# remove duplicates
+toblind = np.unique(toblind)
+
+# total number of events (from last Ge channel loaded, should be same for all Ge channels)
+allind = np.arange(len(daqenergy))
+
+# gets events that should not be blinded
+tokeep = allind[np.logical_not(np.isin(allind, toblind))]
+
+for channel in all_channels:
+    try:
+        chnum = int(channel[2::])
+    except ValueError:
+        # if this isn't an interesting channel, just copy it to the output file
+        chobj, _ = store.read_object(channel, args.input)
+        store.write_object(chobj, channel, lh5_file=args.output, wo_mode='overwrite')
+        continue
+    
+    if (chnum not in list(ged_channels)) and (chnum not in list(spms_channels)):
+        # if this is a PMT or not included for some reason, just copy it to the output file
+        chobj, _ = store.read_object(channel+'/raw', args.input)
+        store.write_object(chobj, group=channel, name='raw', lh5_file=args.output, wo_mode='overwrite')
+        continue
+
+    # the rest should be the Ge and SiPM channels that need to be blinded
 
     # read in all of the data but only for the unblinded events
-    # this says 'idx empty after culling.' but it seems to work?
-    # I made a pull request for lgdo to fix this bug.
-    blinded_chobj, _ = store.read_object(channel + "/raw", args.input, idx=tokeep)
+    blinded_chobj, _  = store.read_object(channel+'/raw', args.input, idx=tokeep)
 
     # now write the blinded data for this channel
-    store.write_object(
-        blinded_chobj, group=channel, name="raw", lh5_file=args.output, wo_mode="overwrite"
-    )
-
-# think this was probably for testing
-# pathlib.Path(args.output).touch()
+    store.write_object(blinded_chobj, group=channel, name='raw', lh5_file=args.output, wo_mode='overwrite')

--- a/scripts/build_raw_blind.py
+++ b/scripts/build_raw_blind.py
@@ -1,14 +1,23 @@
 """
 This script takes in raw data, applies the calibration to the daqenergy
-and uses this to blind the data in a window of Qbb +- 25 keV.
+and uses this to blind the data in a window of Qbb +- 25 keV. It copies over all
+channels in a raw file, removing those events that fall within the ROI for Ge detectors
+that have a daqenergy calibration curve and are not anti-coincidence only (AC).
+
+In the Snakemake dataflow, this script only runs if the checkfile is found on disk,
+but this is controlled by the Snakemake flow (presumably an error is thrown if the file
+is not found). This script itself does not check for the existence of such a file.
 """
 
 import argparse
 import logging
 import os
 import pathlib
-
+import numexpr as ne
+import numpy as np
+from legendmeta import LegendMetadata
 from legendmeta.catalog import Props
+import lgdo.lh5_store as lh5
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument("input", help="input file", type=str)
@@ -26,6 +35,66 @@ logging.basicConfig(level=logging.INFO, filename=args.log, filemode="w")
 
 pathlib.Path(os.path.dirname(args.output)).mkdir(parents=True, exist_ok=True)
 
-blinding_curve = Props.read_from(args.blind_curve)
+Qbb = 2039.061 # keV
+ROI = 25.0 # keV
 
-pathlib.Path(args.output).touch()
+# list of all channels and objects in the raw file
+all_channels = lh5.ls(args.input)
+
+# list of just germanium channels with associated metadata
+# I'm not sure if this is supposed to be "daq.fcid" or "daq.fc_channel" 
+# (from a recent pull that renamed it) or "daq.rawid", which is what I've chosen for now
+chmap = LegendMetadata(path=args.chan_maps)
+ged_channels = chmap.channelmap(args.timestamp).map("system", unique=False)["geds"].map("daq.rawid")
+
+store = lh5.LH5Store()
+
+for channel in all_channels:
+    try:
+        chnum = int(channel[2::])
+    except ValueError:
+        # if this isn't an interesting channel, just copy it to the output file
+        chobj, _ = store.read_object(channel, args.input)
+        store.write_object(chobj, channel, args.output, wo_mode='overwrite')
+        continue
+    
+    if chnum not in list(ged_channels):
+        # if this is a SiPM or Ge not included for some reason, just copy it to the output file
+        chobj, _ = store.read_object(channel+'/raw', args.input)
+        store.write_object(chobj, group=channel, name='raw', lh5_file=args.output, wo_mode='overwrite')
+        continue
+
+    if ged_channels[chnum]["analysis"]["usability"] == 'ac':
+        # if this Ge is to be used for anti-coincidence only, it will not have a blinding calibration
+        # (or at least it should not be blinded) so just copy it to the output file
+        chobj, _ = store.read_object(channel+'/raw', args.input)
+        store.write_object(chobj, group=channel, name='raw', lh5_file=args.output, wo_mode='overwrite')
+        continue
+
+    # the rest should be the Ge channels that need to be blinded
+
+    # load in just the daqenergy for now
+    daqenergy, _  = store.read_object(channel+'/raw/daqenergy', args.input)
+
+    # read in calibration curve for this channel
+    blind_curve = Props.read_from(args.blind_curve)[channel]
+
+    # calibrate daq energy using pre existing curve
+    daqenergy_cal = ne.evaluate(
+        blind_curve["daqenergy_cal"]["expression"],
+        local_dict=dict(daqenergy=daqenergy, **blind_curve["daqenergy_cal"]["parameters"]),
+    )
+
+    # figure out which events should be kept unblinded
+    tokeep = np.nonzero(np.abs(np.asarray(daqenergy_cal) - Qbb) > ROI)[0]
+
+    # read in all of the data but only for the unblinded events
+    # this says 'idx empty after culling.' but it seems to work?
+    # I made a pull request for lgdo to fix this bug.
+    blinded_chobj, _  = store.read_object(channel+'/raw', args.input, idx=tokeep)
+
+    # now write the blinded data for this channel
+    store.write_object(blinded_chobj, group=channel, name='raw', lh5_file=args.output, wo_mode='overwrite')
+    
+# think this was probably for testing
+# pathlib.Path(args.output).touch()


### PR DESCRIPTION
I added the blinding implementation. It copies over all channels in a `raw` file, removing those events that fall within the ROI for Ge detectors that have a `daqenergy` calibration curve and are not anti-coincidence only (`ac`). I am not able to check that this works with `snakemake` myself, however.