### PR TITLE
Fix indentation of `analysis_runs` definition in `create_filelist.py`

### DIFF
--- a/scripts/create_filelist.py
+++ b/scripts/create_filelist.py
@@ -31,9 +31,9 @@ if snakemake.params.configs:
         if os.path.isfile(snakemake.params.analysis_runs_file):
             with open(snakemake.params.analysis_runs_file) as f:
                 analysis_runs = json.load(f)
-        else:
-            analysis_runs = []
-            print("no analysis_runs file found")
+    else:
+        analysis_runs = []
+        print("no analysis_runs file found")
 
 key = FileKey.parse_keypart(keypart)
 


### PR DESCRIPTION
In the case that the `analysis_runs_file` is `None` in the Snakefile being used, the variable `analysis_runs` will be undefined. This is due to the `else` statement that would define after checking for the `analysis_runs_file` being indented once too far.

This PR fixes that indentation.