### PR TITLE
Fixes for NERSC

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -111,7 +111,6 @@ onstart:
     )
 
 
-
 onsuccess:
     from snakemake.report import auto_report
 

--- a/Snakefile
+++ b/Snakefile
@@ -103,6 +103,14 @@ onstart:
         {"cal": ["par_dsp"], "lar": ["par_dsp"]},
     )
 
+    ds.pars_key_resolve.write_par_catalog(
+        ["-*-*-*-cal"],
+        os.path.join(pars_path(setup), "pht", "validity.jsonl"),
+        get_pattern_tier_raw(setup),
+        {"cal": ["par_pht"], "lar": ["par_pht"]},
+    )
+
+
 
 onsuccess:
     from snakemake.report import auto_report

--- a/Snakefile
+++ b/Snakefile
@@ -83,32 +83,30 @@ onstart:
     # Make sure numba processors are compiled before we begin
     shell('{swenv} python3 -B -c "import dspeed; import lgdo"')
 
-    if os.path.isfile(os.path.join(pars_path(setup), "hit", "validity.jsonl")):
+    # Log parameter catalogs in validity.jsonl files
+    hit_par_cat_file = os.path.join(pars_path(setup), "hit", "validity.jsonl")
+    if os.path.isfile(hit_par_cat_file):
         os.remove(os.path.join(pars_path(setup), "hit", "validity.jsonl"))
+    pathlib.Path(os.path.dirname(hit_par_cat_file)).mkdir(parents=True, exist_ok=True)
+    ds.pars_key_resolve.write_to_jsonl(hit_par_catalog, hit_par_cat_file)
 
-    ds.pars_key_resolve.write_par_catalog(
-        ["-*-*-*-cal"],
-        os.path.join(pars_path(setup), "hit", "validity.jsonl"),
-        get_pattern_tier_raw(setup),
-        {"cal": ["par_hit"], "lar": ["par_hit"]},
-    )
+    pht_par_cat_file = os.path.join(pars_path(setup), "pht", "validity.jsonl")
+    if os.path.isfile(pht_par_cat_file):
+        os.remove(os.path.join(pars_path(setup), "pht", "validity.jsonl"))
+    pathlib.Path(os.path.dirname(pht_par_cat_file)).mkdir(parents=True, exist_ok=True)
+    ds.pars_key_resolve.write_to_jsonl(pht_par_catalog, pht_par_cat_file)
 
-    if os.path.isfile(os.path.join(pars_path(setup), "dsp", "validity.jsonl")):
-        os.remove(os.path.join(pars_path(setup), "dsp", "validity.jsonl"))
+    dsp_par_cat_file = os.path.join(pars_path(setup), "dsp", "validity.jsonl")
+    if os.path.isfile(dsp_par_cat_file):
+        os.remove(dsp_par_cat_file)
+    pathlib.Path(os.path.dirname(dsp_par_cat_file)).mkdir(parents=True, exist_ok=True)
+    ds.pars_key_resolve.write_to_jsonl(dsp_par_catalog, dsp_par_cat_file)
 
-    ds.pars_key_resolve.write_par_catalog(
-        ["-*-*-*-cal"],
-        os.path.join(pars_path(setup), "dsp", "validity.jsonl"),
-        get_pattern_tier_raw(setup),
-        {"cal": ["par_dsp"], "lar": ["par_dsp"]},
-    )
-
-    ds.pars_key_resolve.write_par_catalog(
-        ["-*-*-*-cal"],
-        os.path.join(pars_path(setup), "pht", "validity.jsonl"),
-        get_pattern_tier_raw(setup),
-        {"cal": ["par_pht"], "lar": ["par_pht"]},
-    )
+    psp_par_cat_file = os.path.join(pars_path(setup), "psp", "validity.jsonl")
+    if os.path.isfile(psp_par_cat_file):
+        os.remove(psp_par_cat_file)
+    pathlib.Path(os.path.dirname(psp_par_cat_file)).mkdir(parents=True, exist_ok=True)
+    ds.pars_key_resolve.write_to_jsonl(psp_par_catalog, psp_par_cat_file)
 
 
 onsuccess:

--- a/Snakefile
+++ b/Snakefile
@@ -80,6 +80,9 @@ localrules:
 onstart:
     print("INFO: starting workflow")
 
+    # Make sure numba processors are compiled before we begin
+    shell("{swenv} python3 -B -c \"import dspeed; import lgdo\"")
+
     if os.path.isfile(os.path.join(pars_path(setup), "hit", "validity.jsonl")):
         os.remove(os.path.join(pars_path(setup), "hit", "validity.jsonl"))
 

--- a/Snakefile-build-raw
+++ b/Snakefile-build-raw
@@ -53,9 +53,8 @@ localrules:
     autogen_output,
 
 
-ds.pars_key_resolve.write_par_catalog(
+raw_par_catalog = ds.pars_key_resolve.get_par_catalog(
     ["-*-*-*-cal"],
-    os.path.join(pars_path(setup), "raw", "validity.jsonl"),
     [
         get_pattern_unsorted_data(setup),
         get_pattern_tier_daq(setup),
@@ -67,6 +66,12 @@ ds.pars_key_resolve.write_par_catalog(
 
 onstart:
     print("Starting workflow")
+
+    raw_par_cat_file = os.path.join(pars_path(setup), "raw", "validity.jsonl")
+    if os.path.isfile(raw_par_cat_file):
+        os.remove(os.path.join(pars_path(setup), "raw", "validity.jsonl"))
+    pathlib.Path(os.path.dirname(raw_par_cat_file)).mkdir(parents=True, exist_ok=True)
+    ds.pars_key_resolve.write_to_jsonl(raw_par_catalog, raw_par_cat_file)
 
 
 onsuccess:

--- a/rules/chanlist_gen.smk
+++ b/rules/chanlist_gen.smk
@@ -21,8 +21,10 @@ def get_par_chanlist(
 
     key = ChannelProcKey.parse_keypart(keypart)
 
+    flist_path = filelist_path(setup)
+    os.makedirs(flist_path, exist_ok=True)
     output_file = os.path.join(
-        filelist_path(setup),
+        flist_path,
         f"all-{key.experiment}-{key.period}-{key.run}-cal-{key.timestamp}-channels.chankeylist.{random.randint(0,99999):05d}",
     )
 

--- a/rules/hit.smk
+++ b/rules/hit.smk
@@ -20,6 +20,12 @@ from scripts.util.patterns import (
     get_pattern_pars,
 )
 
+hit_par_catalog = ds.pars_key_resolve.get_par_catalog(
+    ["-*-*-*-cal"],
+    get_pattern_tier_raw(setup),
+    {"cal": ["par_hit"], "lar": ["par_hit"]},
+)
+
 
 # This rule builds the qc using the calibration dsp files and fft files
 rule build_qc:

--- a/rules/main.smk
+++ b/rules/main.smk
@@ -10,6 +10,10 @@ from scripts.util.utils import (
 
 timestamp = datetime.strftime(datetime.utcnow(), "%Y%m%dT%H%M%SZ")
 
+# Make sure that numba procesors are compiled before we begin
+onstart:
+    shell('python3 -c "import dspeed; import lgdo"')
+
 
 # Create "{label}-{tier}.gen", based on "{label}.keylist" via
 # "{label}-{tier}.filelist". Will implicitly trigger creation of all files in

--- a/rules/main.smk
+++ b/rules/main.smk
@@ -10,11 +10,6 @@ from scripts.util.utils import (
 
 timestamp = datetime.strftime(datetime.utcnow(), "%Y%m%dT%H%M%SZ")
 
-# Make sure that numba procesors are compiled before we begin
-onstart:
-    shell('python3 -c "import dspeed; import lgdo"')
-
-
 # Create "{label}-{tier}.gen", based on "{label}.keylist" via
 # "{label}-{tier}.filelist". Will implicitly trigger creation of all files in
 # "{label}-{tier}.filelist". Example:

--- a/rules/pht.smk
+++ b/rules/pht.smk
@@ -21,13 +21,6 @@ from scripts.util.patterns import (
     get_pattern_pars,
 )
 
-ds.pars_key_resolve.write_par_catalog(
-    ["-*-*-*-cal"],
-    os.path.join(pars_path(setup), "pht", "validity.jsonl"),
-    get_pattern_tier_raw(setup),
-    {"cal": ["par_pht"], "lar": ["par_pht"]},
-)
-
 intier = "psp"
 
 

--- a/rules/pht.smk
+++ b/rules/pht.smk
@@ -21,6 +21,12 @@ from scripts.util.patterns import (
     get_pattern_pars,
 )
 
+pht_par_catalog = ds.pars_key_resolve.get_par_catalog(
+    ["-*-*-*-cal"],
+    get_pattern_tier_raw(setup),
+    {"cal": ["par_pht"], "lar": ["par_pht"]},
+)
+
 intier = "psp"
 
 
@@ -47,7 +53,7 @@ for key, dataset in part.datasets.items():
                 pulser_files=[
                     file.replace("par_pht", "par_tcm")
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -55,7 +61,7 @@ for key, dataset in part.datasets.items():
                     )
                 ],
                 check_files=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -64,7 +70,7 @@ for key, dataset in part.datasets.items():
                 overwrite_files=get_overwrite_file(
                     "pht",
                     timestamp=part.get_timestamp(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -76,13 +82,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -92,7 +98,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -101,7 +107,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",
@@ -255,7 +261,7 @@ for key, dataset in part.datasets.items():
                 pulser_files=[
                     file.replace("par_pht", "par_tcm")
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -263,14 +269,14 @@ for key, dataset in part.datasets.items():
                     )
                 ],
                 ecal_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
                     name="energy_cal",
                 ),
                 eres_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -278,7 +284,7 @@ for key, dataset in part.datasets.items():
                     extension="pkl",
                 ),
                 inplots=part.get_plt_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -290,13 +296,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -306,7 +312,7 @@ for key, dataset in part.datasets.items():
                 partcal_results=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -317,7 +323,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -326,7 +332,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",
@@ -437,7 +443,7 @@ for key, dataset in part.datasets.items():
                 pulser_files=[
                     file.replace("par_pht", "par_tcm")
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -445,14 +451,14 @@ for key, dataset in part.datasets.items():
                     )
                 ],
                 ecal_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
                     name="partcal",
                 ),
                 eres_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -460,7 +466,7 @@ for key, dataset in part.datasets.items():
                     extension="pkl",
                 ),
                 inplots=part.get_plt_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -472,13 +478,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -488,7 +494,7 @@ for key, dataset in part.datasets.items():
                 aoe_results=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -499,7 +505,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -508,7 +514,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",
@@ -617,7 +623,7 @@ for key, dataset in part.datasets.items():
                 pulser_files=[
                     file.replace("par_pht", "par_tcm")
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -625,14 +631,14 @@ for key, dataset in part.datasets.items():
                     )
                 ],
                 ecal_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
                     name="aoecal",
                 ),
                 eres_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -640,7 +646,7 @@ for key, dataset in part.datasets.items():
                     extension="pkl",
                 ),
                 inplots=part.get_plt_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -652,13 +658,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -667,7 +673,7 @@ for key, dataset in part.datasets.items():
                 lq_results=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -678,7 +684,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -686,7 +692,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",

--- a/rules/pht_fast.smk
+++ b/rules/pht_fast.smk
@@ -24,7 +24,7 @@ for key, dataset in part.datasets.items():
                 pulser_files=[
                     file.replace("par_pht", "par_tcm")
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -32,14 +32,14 @@ for key, dataset in part.datasets.items():
                     )
                 ],
                 ecal_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
                     name="energy_cal",
                 ),
                 eres_file=part.get_par_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -47,7 +47,7 @@ for key, dataset in part.datasets.items():
                     extension="pkl",
                 ),
                 inplots=part.get_plt_files(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     tier="pht",
@@ -59,13 +59,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -74,7 +74,7 @@ for key, dataset in part.datasets.items():
                 partcal_results=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -85,7 +85,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -93,7 +93,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",

--- a/rules/psp.smk
+++ b/rules/psp.smk
@@ -20,16 +20,14 @@ from scripts.util.patterns import (
     get_pattern_pars,
 )
 
-pars_key_resolve.write_par_catalog(
+dsp_par_catalog = pars_key_resolve.get_par_catalog(
     ["-*-*-*-cal"],
-    os.path.join(pars_path(setup), "dsp", "validity.jsonl"),
     get_pattern_tier_raw(setup),
     {"cal": ["par_dsp"], "lar": ["par_dsp"]},
 )
 
-pars_key_resolve.write_par_catalog(
+psp_par_catalog = pars_key_resolve.get_par_catalog(
     ["-*-*-*-cal"],
-    os.path.join(pars_path(setup), "psp", "validity.jsonl"),
     get_pattern_tier_raw(setup),
     {"cal": ["par_psp"], "lar": ["par_psp"]},
 )
@@ -41,14 +39,14 @@ for key, dataset in part.datasets.items():
         rule:
             input:
                 dsp_pars=part.get_par_files(
-                    f"{par_dsp_path(setup)}/validity.jsonl",
+                    dsp_par_catalog,
                     partition,
                     key,
                     tier="dsp",
                     name="eopt",
                 ),
                 dsp_objs=part.get_par_files(
-                    f"{par_dsp_path(setup)}/validity.jsonl",
+                    dsp_par_catalog,
                     partition,
                     key,
                     tier="dsp",
@@ -56,7 +54,7 @@ for key, dataset in part.datasets.items():
                     extension="pkl",
                 ),
                 dsp_plots=part.get_plt_files(
-                    f"{par_dsp_path(setup)}/validity.jsonl", partition, key, tier="dsp"
+                    dsp_par_catalog, partition, key, tier="dsp"
                 ),
             wildcard_constraints:
                 channel=part.get_wildcard_constraints(partition, key),
@@ -64,12 +62,12 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_psp_path(setup)}/validity.jsonl", partition, key, tier="psp"
+                    psp_par_catalog, partition, key, tier="psp"
                 ),
             output:
                 psp_pars=temp(
                     part.get_par_files(
-                        f"{par_psp_path(setup)}/validity.jsonl",
+                        psp_par_catalog,
                         partition,
                         key,
                         tier="psp",
@@ -78,7 +76,7 @@ for key, dataset in part.datasets.items():
                 ),
                 psp_objs=temp(
                     part.get_par_files(
-                        f"{par_psp_path(setup)}/validity.jsonl",
+                        psp_par_catalog,
                         partition,
                         key,
                         tier="psp",
@@ -88,7 +86,7 @@ for key, dataset in part.datasets.items():
                 ),
                 psp_plots=temp(
                     part.get_plt_files(
-                        f"{par_psp_path(setup)}/validity.jsonl",
+                        psp_par_catalog,
                         partition,
                         key,
                         tier="psp",
@@ -96,7 +94,7 @@ for key, dataset in part.datasets.items():
                 ),
             log:
                 part.get_log_file(
-                    f"{par_psp_path(setup)}/validity.jsonl",
+                    psp_par_catalog,
                     partition,
                     key,
                     "psp",

--- a/rules/qc_phy.smk
+++ b/rules/qc_phy.smk
@@ -29,13 +29,13 @@ for key, dataset in part.datasets.items():
                 datatype="cal",
                 channel="{channel}" if key == "default" else key,
                 timestamp=part.get_timestamp(
-                    f"{par_pht_path(setup)}/validity.jsonl", partition, key, tier="pht"
+                    pht_par_catalog, partition, key, tier="pht"
                 ),
             output:
                 hit_pars=[
                     temp(file)
                     for file in part.get_par_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -45,7 +45,7 @@ for key, dataset in part.datasets.items():
                 plot_file=[
                     temp(file)
                     for file in part.get_plt_files(
-                        f"{par_pht_path(setup)}/validity.jsonl",
+                        pht_par_catalog,
                         partition,
                         key,
                         tier="pht",
@@ -54,7 +54,7 @@ for key, dataset in part.datasets.items():
                 ],
             log:
                 part.get_log_file(
-                    f"{par_pht_path(setup)}/validity.jsonl",
+                    pht_par_catalog,
                     partition,
                     key,
                     "pht",

--- a/rules/tcm.smk
+++ b/rules/tcm.smk
@@ -46,6 +46,9 @@ rule build_pulser_ids:
         ),
     params:
         input=lambda _, input: ro(input),
+        timestamp="{timestamp}",
+        datatype="cal",
+        channel="{channel}",
     output:
         pulser=temp(get_pattern_pars_tmp_channel(setup, "tcm", "pulser_ids")),
     log:
@@ -58,7 +61,7 @@ rule build_pulser_ids:
         "{swenv} python3 -B "
         "{basedir}/../scripts/pars_tcm_pulser.py "
         "--log {log} "
-        r"--configs {ro(configs)} "
+        f"--configs {ro(configs)} "
         "--datatype {params.datatype} "
         "--timestamp {params.timestamp} "
         "--channel {params.channel} "

--- a/scripts/blinding_calibration.py
+++ b/scripts/blinding_calibration.py
@@ -18,9 +18,6 @@ from lgdo import lh5
 from pygama.math.histogram import better_int_binning, get_hist
 from pygama.pargen.energy_cal import hpge_find_E_peaks
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-
 mpl.use("agg")
 
 argparser = argparse.ArgumentParser()

--- a/scripts/build_dsp.py
+++ b/scripts/build_dsp.py
@@ -12,11 +12,6 @@ from legendmeta import TextDB
 from legendmeta.catalog import Props
 from lgdo import lh5
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-
 
 def replace_list_with_array(dic):
     for key, value in dic.items():

--- a/scripts/build_raw.py
+++ b/scripts/build_raw.py
@@ -8,9 +8,6 @@ from daq2lh5 import build_raw
 from legendmeta import TextDB
 from legendmeta.catalog import Props
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-
 argparser = argparse.ArgumentParser()
 argparser.add_argument("input", help="input file", type=str)
 argparser.add_argument("output", help="output file", type=str)

--- a/scripts/build_raw_blind.py
+++ b/scripts/build_raw_blind.py
@@ -15,9 +15,6 @@ import logging
 import os
 import pathlib
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-
 import numexpr as ne
 import numpy as np
 from legendmeta import LegendMetadata, TextDB

--- a/scripts/complete_run.py
+++ b/scripts/complete_run.py
@@ -2,14 +2,9 @@
 
 import datetime
 import glob
-import json
 import os
-import subprocess
-import time
-from datetime import timedelta
 from pathlib import Path
 
-import util.patterns as pat
 import util.utils as ut
 from util.FileKey import FileKey
 

--- a/scripts/complete_run.py
+++ b/scripts/complete_run.py
@@ -190,9 +190,9 @@ def build_file_dbs(gen_tier_path, outdir):
         logfile = Path(ut.tmp_log_path(snakemake.params.setup)) / outfile.with_suffix(".log").name
         print(f"INFO: ......building {outfile}")
 
-        cmdline, cmdenv = ut.runcmd_popen(snakemake.params.setup)
-
-        cmdenv["PRODENV"] = as_ro(os.getenv("PRODENV"))
+        cmdline = ut.runcmd(snakemake.params.setup, aslist=True)
+        prodenv = as_ro(os.getenv("PRODENV"))
+        cmdline += [f"--env=PRODENV={prodenv}"]
 
         # TODO: forward stdout to log file
         processes.add(
@@ -212,7 +212,6 @@ def build_file_dbs(gen_tier_path, outdir):
                     str(logfile),
                     "--assume-nonsparse" if speck[0] == "phy" else "",
                 ],
-                env=cmdenv,
             )
         )
 

--- a/scripts/merge_channels.py
+++ b/scripts/merge_channels.py
@@ -69,7 +69,7 @@ if file_extension == ".json" or file_extension == ".yaml" or file_extension == "
             msg = "Output file extension does not match input file extension"
             raise RuntimeError(msg)
 
-    Props.write_to(temp_output, out_dict)
+    Props.write_to(temp_output, out_dict, "json")
 
     os.rename(temp_output, out_file)
 

--- a/scripts/pars_dsp_build_svm.py
+++ b/scripts/pars_dsp_build_svm.py
@@ -7,11 +7,6 @@ from legendmeta.catalog import Props
 from lgdo import lh5
 from sklearn.svm import SVC
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-
 argparser = argparse.ArgumentParser()
 argparser.add_argument("--log", help="log file", type=str)
 argparser.add_argument("--output_file", help="output SVM file", type=str, required=True)

--- a/scripts/pars_dsp_dplms.py
+++ b/scripts/pars_dsp_dplms.py
@@ -12,13 +12,6 @@ from legendmeta.catalog import Props
 from lgdo import Array, Table
 from pygama.pargen.dplms_ge_dict import dplms_ge_dict
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 argparser = argparse.ArgumentParser()
 argparser.add_argument("--fft_raw_filelist", help="fft_raw_filelist", type=str)
 argparser.add_argument("--peak_file", help="tcm_filelist", type=str, required=True)

--- a/scripts/pars_dsp_eopt.py
+++ b/scripts/pars_dsp_eopt.py
@@ -6,13 +6,6 @@ import pickle as pkl
 import time
 import warnings
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import numpy as np
 import pygama.pargen.energy_optimisation as om  # noqa: F401

--- a/scripts/pars_dsp_event_selection.py
+++ b/scripts/pars_dsp_event_selection.py
@@ -5,14 +5,6 @@ import os
 import pathlib
 import time
 import warnings
-
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 from bisect import bisect_left
 
 import lgdo

--- a/scripts/pars_dsp_nopt.py
+++ b/scripts/pars_dsp_nopt.py
@@ -5,13 +5,6 @@ import pathlib
 import pickle as pkl
 import time
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import numpy as np
 import pygama.pargen.noise_optimization as pno

--- a/scripts/pars_dsp_tau.py
+++ b/scripts/pars_dsp_tau.py
@@ -4,13 +4,6 @@ import os
 import pathlib
 import pickle as pkl
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["DSPEED_CACHE"] = "false"
-os.environ["DSPEED_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import numpy as np
 from legendmeta import LegendMetadata

--- a/scripts/pars_hit_aoe.py
+++ b/scripts/pars_hit_aoe.py
@@ -8,9 +8,6 @@ import pickle as pkl
 import warnings
 from typing import Callable
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 from legendmeta import LegendMetadata

--- a/scripts/pars_hit_ecal.py
+++ b/scripts/pars_hit_ecal.py
@@ -9,9 +9,6 @@ import pickle as pkl
 import warnings
 from datetime import datetime
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import matplotlib as mpl
 import matplotlib.pyplot as plt

--- a/scripts/pars_hit_lq.py
+++ b/scripts/pars_hit_lq.py
@@ -7,9 +7,6 @@ import pathlib
 import pickle as pkl
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 from legendmeta import LegendMetadata

--- a/scripts/pars_hit_qc.py
+++ b/scripts/pars_hit_qc.py
@@ -9,9 +9,6 @@ import pickle as pkl
 import re
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 from legendmeta import LegendMetadata
 from legendmeta.catalog import Props

--- a/scripts/pars_pht_aoecal.py
+++ b/scripts/pars_pht_aoecal.py
@@ -10,9 +10,6 @@ import re
 import warnings
 from typing import Callable
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 from legendmeta import LegendMetadata

--- a/scripts/pars_pht_fast.py
+++ b/scripts/pars_pht_fast.py
@@ -8,9 +8,6 @@ import pathlib
 import pickle as pkl
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 from legendmeta import LegendMetadata

--- a/scripts/pars_pht_lqcal.py
+++ b/scripts/pars_pht_lqcal.py
@@ -9,9 +9,6 @@ import pathlib
 import pickle as pkl
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 from legendmeta import LegendMetadata

--- a/scripts/pars_pht_partcal.py
+++ b/scripts/pars_pht_partcal.py
@@ -9,9 +9,6 @@ import pickle as pkl
 import re
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 import pandas as pd
 import pygama.math.distributions as pgf

--- a/scripts/pars_pht_qc.py
+++ b/scripts/pars_pht_qc.py
@@ -9,9 +9,6 @@ import pickle as pkl
 import re
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import numpy as np
 from legendmeta import LegendMetadata
 from legendmeta.catalog import Props

--- a/scripts/pars_pht_qc_phy.py
+++ b/scripts/pars_pht_qc_phy.py
@@ -9,9 +9,6 @@ import pickle as pkl
 import re
 import warnings
 
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import numpy as np
 from legendmeta import LegendMetadata

--- a/scripts/pars_tcm_pulser.py
+++ b/scripts/pars_tcm_pulser.py
@@ -3,11 +3,6 @@ import logging
 import os
 import pathlib
 
-os.environ["LGDO_CACHE"] = "false"
-os.environ["LGDO_BOUNDSCHECK"] = "false"
-os.environ["PYGAMA_PARALLEL"] = "false"
-os.environ["PYGAMA_FASTMATH"] = "false"
-
 import lgdo.lh5 as lh5
 import numpy as np
 from legendmeta import LegendMetadata

--- a/scripts/util/create_pars_keylist.py
+++ b/scripts/util/create_pars_keylist.py
@@ -4,8 +4,6 @@ This module creates the validity files used for determining the time validity of
 
 import glob
 import json
-import os
-import pathlib
 import re
 import warnings
 from typing import ClassVar
@@ -112,7 +110,7 @@ class pars_key_resolve:
         return keys
 
     @staticmethod
-    def write_par_catalog(keypart, filename, search_patterns, name_dict):
+    def get_par_catalog(keypart, search_patterns, name_dict):
         if isinstance(keypart, str):
             keypart = [keypart]
         if isinstance(search_patterns, str):
@@ -126,10 +124,8 @@ class pars_key_resolve:
             keylist = pars_key_resolve.generate_par_keylist(keys)
 
             entrylist = pars_key_resolve.match_all_entries(keylist, name_dict)
-            pathlib.Path(os.path.dirname(filename)).mkdir(parents=True, exist_ok=True)
-            pars_key_resolve.write_to_jsonl(entrylist, filename)
         else:
             msg = "No Keys found"
             warnings.warn(msg, stacklevel=0)
             entrylist = [pars_key_resolve("00000000T000000Z", "all", [])]
-            pars_key_resolve.write_to_jsonl(entrylist, filename)
+        return entrylist

--- a/scripts/util/dataset_cal.py
+++ b/scripts/util/dataset_cal.py
@@ -5,7 +5,6 @@ This module uses the partition database files to the necessary inputs for partit
 import json
 import os
 
-from .CalibCatalog import PropsStream
 from .FileKey import ChannelProcKey, ProcessingFileKey
 from .patterns import (
     get_pattern_log_channel,
@@ -50,7 +49,7 @@ class dataset_file:
 
     def get_par_files(
         self,
-        catalog_file,
+        catalog,
         dataset,
         channel,
         tier,
@@ -61,8 +60,8 @@ class dataset_file:
     ):
         dataset = self.get_dataset(dataset, channel)
         all_par_files = []
-        for item in PropsStream.read_from(catalog_file):
-            par_files = item["apply"]
+        for item in catalog:
+            par_files = item.apply
             for par_file in par_files:
                 if par_file.split("-")[-1] == f"par_{tier}.json":
                     all_par_files.append(par_file)
@@ -99,7 +98,7 @@ class dataset_file:
 
     def get_plt_files(
         self,
-        catalog_file,
+        catalog,
         dataset,
         channel,
         tier,
@@ -109,8 +108,8 @@ class dataset_file:
     ):
         dataset = self.get_dataset(dataset, channel)
         all_par_files = []
-        for item in PropsStream.read_from(catalog_file):
-            par_files = item["apply"]
+        for item in catalog:
+            par_files = item.apply
             for par_file in par_files:
                 if par_file.split("-")[-1] == f"par_{tier}.json":
                     all_par_files.append(par_file)
@@ -143,7 +142,7 @@ class dataset_file:
 
     def get_log_file(
         self,
-        catalog_file,
+        catalog,
         dataset,
         channel,
         tier,
@@ -152,7 +151,7 @@ class dataset_file:
         name=None,
     ):
         par_files = self.get_par_files(
-            catalog_file,
+            catalog,
             dataset,
             channel,
             tier,
@@ -167,11 +166,9 @@ class dataset_file:
             fk.channel = channel
         return fk.get_path_from_filekey(get_pattern_log_channel(self.setup, name))[0]
 
-    def get_timestamp(
-        self, catalog_file, dataset, channel, tier, experiment="l200", datatype="cal"
-    ):
+    def get_timestamp(self, catalog, dataset, channel, tier, experiment="l200", datatype="cal"):
         par_files = self.get_par_files(
-            catalog_file,
+            catalog,
             dataset,
             channel,
             tier,

--- a/scripts/util/utils.py
+++ b/scripts/util/utils.py
@@ -205,18 +205,19 @@ def filelist_path(setup):
 def runcmd(setup, aslist=False):
     exec_cmd = shlex.split(setup["execenv"]["cmd"])
     exec_arg = shlex.split(setup["execenv"]["arg"])
+    
     path_install = setup["paths"]["install"]
-
-    cmdline = (
-        f"PYTHONUSERBASE={path_install}",
-        "APPTAINERENV_PREPEND_PATH={path_install}/bin",
-        *exec_cmd,
-        *exec_arg,
-    )
+    exec_env = ["--env=PYTHONUSERBASE={path_install}"]
 
     if "env" in setup["execenv"]:
         for k, v in setup["execenv"]["env"].items():
-            cmdline = [f"{k}={v}", *cmdline]
+            exec_env += [f"--env={k}={v}"]
+
+    cmdline = [
+        *exec_cmd,
+        *exec_arg,
+        *exec_env,
+    ]
 
     if aslist:
         return cmdline

--- a/scripts/util/utils.py
+++ b/scripts/util/utils.py
@@ -203,42 +203,17 @@ def filelist_path(setup):
 
 
 def runcmd(setup, aslist=False):
-    exec_cmd = shlex.split(setup["execenv"]["cmd"])
-    exec_arg = shlex.split(setup["execenv"]["arg"])
-    
-    path_install = setup["paths"]["install"]
-    exec_env = ["--env=PYTHONUSERBASE={path_install}"]
-
+    cmdline  = shlex.split(setup["execenv"]["cmd"])
+    cmdline += shlex.split(setup["execenv"]["arg"])
+    cmdline += [f"--env=PYTHONUSERBASE={setup['paths']['install']}"]
     if "env" in setup["execenv"]:
-        for k, v in setup["execenv"]["env"].items():
-            exec_env += [f"--env={k}={v}"]
-
-    cmdline = [
-        *exec_cmd,
-        *exec_arg,
-        *exec_env,
-    ]
+        cmdline += [ f"--env={var}=\"{val}\"" for var, val in setup["execenv"]["env"].items() ]
+        
 
     if aslist:
         return cmdline
 
     return " ".join(cmdline)
-
-
-def runcmd_popen(setup):
-    exec_cmd = shlex.split(setup["execenv"]["cmd"])
-    exec_arg = shlex.split(setup["execenv"]["arg"])
-    path_install = setup["paths"]["install"]
-
-    cmdenv = {
-        "PYTHONUSERBASE": path_install,
-        "APPTAINERENV_PREPEND_PATH": f"{path_install}/bin",
-    }
-
-    if "env" in setup["execenv"]:
-        cmdenv |= setup["execenv"]["env"]
-
-    return exec_cmd + exec_arg, cmdenv
 
 
 def subst_vars_impl(x, var_values, ignore_missing=False):

--- a/templates/config.json
+++ b/templates/config.json
@@ -50,7 +50,16 @@
 
       "execenv": {
         "cmd": "apptainer run",
-        "arg": "/data2/public/prodenv/containers/legendexp_legend-base_latest_20221021210158.sif"
+        "arg": "/data2/public/prodenv/containers/legendexp_legend-base_latest_20221021210158.sif",
+	"env": {
+	    "HDF5_USE_FILE_LOCKING": "False",
+	    "LGDO_CACHE": "false",
+	    "LGDO_BOUNDSCHECK": "false",
+	    "DSPEED_CACHE": "false",
+	    "DSPEED_BOUNDSCHECK": "false",
+	    "PYGAMA_PARALLEL": "false",
+	    "PYGAMA_FASTMATH": "false"
+	}
       },
       "pkg_versions": {
         "pygama": "pygama==2.0.1",

--- a/templates/config.json
+++ b/templates/config.json
@@ -53,9 +53,7 @@
         "arg": "/data2/public/prodenv/containers/legendexp_legend-base_latest_20221021210158.sif",
 	"env": {
 	    "HDF5_USE_FILE_LOCKING": "False",
-	    "LGDO_CACHE": "false",
 	    "LGDO_BOUNDSCHECK": "false",
-	    "DSPEED_CACHE": "false",
 	    "DSPEED_BOUNDSCHECK": "false",
 	    "PYGAMA_PARALLEL": "false",
 	    "PYGAMA_FASTMATH": "false"


### PR DESCRIPTION
These are some smaller changes I've come up with while trying to run this on NERSC
- There is a directory that doesn't get created correctly during setup, which has been fixed
- Changed how environment variables are handled
  - Set variables in config file; do not hardcode into scripts
  - Variables are fed in using the --env option (which is commonly used between apptainer, shifter, and docker) rather than defining them before the call
  - Note that `APPTAINERENV_PREPEND_PATH={path_install}/bin` has been removed. This is not important at this time since we never directly call anything from `$PATH`. This variable unfortunately does not have an equivalent in shifter or docker as far as I am aware. Unfortunately this makes setting `$PATH` very annoying
- Import dspeed and lgdo before starting the workflow; this prevents a race condition that can happen with clean installs, when multiple jobs are compiling the numba functions at once leading to segfaults
- Turned off the `DSPEED/LGDO_CACHE=false`, which should not be needed anymore