### PR TITLE
Edited ecal file for pile-up analysis calibration

### DIFF
--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -598,7 +598,8 @@ def par_geds_hit_ecal() -> None:
                         np.nanpercentile(e_uncal, 99.9),
                     ],
                 )
-        else: raise ValueError("e_uncal should not be empty!")
+        else:
+            raise ValueError("e_uncal should not be empty!")
         guess = 2614.511 / bins[np.nanargmax(hist)]
         full_object_dict[cal_energy_param] = HPGeCalibration(
             energy_param,

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -598,7 +598,7 @@ def par_geds_hit_ecal() -> None:
                         np.nanpercentile(e_uncal, 99.9),
                     ],
                 )
-
+        else: raise ValueError("e_uncal should not be empty!")
         guess = 2614.511 / bins[np.nanargmax(hist)]
         full_object_dict[cal_energy_param] = HPGeCalibration(
             energy_param,

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -566,9 +566,11 @@ def par_geds_hit_ecal() -> None:
         kwarg_dict["energy_params"], cal_energy_params
     ):
         e_uncal = data.query(selection_string)[energy_param].to_numpy()
-        if len(e_uncal)>0:
-            if (isinstance(e_uncal[0], (np.ndarray, list))):  
-                flattened_e_uncal = np.concatenate([arr for arr in e_uncal if len(arr) > 0])
+        if len(e_uncal) > 0:
+            if isinstance(e_uncal[0], (np.ndarray, list)):
+                flattened_e_uncal = np.concatenate(
+                    [arr for arr in e_uncal if len(arr) > 0]
+                )
 
         hist, bins, bar = pgh.get_hist(
             e_uncal[

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -571,15 +571,24 @@ def par_geds_hit_ecal() -> None:
                 flattened_e_uncal = np.concatenate(
                     [arr for arr in e_uncal if len(arr) > 0]
                 )
-
-        hist, bins, bar = pgh.get_hist(
-            e_uncal[
-                (e_uncal > np.nanpercentile(e_uncal, 95))
-                & (e_uncal < np.nanpercentile(e_uncal, 99.9))
-            ],
-            dx=1,
-            range=[np.nanpercentile(e_uncal, 95), np.nanpercentile(e_uncal, 99.9)],
-        )
+                hist, bins, bar = pgh.get_hist(
+                flattened_e_uncal[
+                    (flattened_e_uncal > np.nanpercentile(flattened_e_uncal, 95))
+                    & (flattened_e_uncal < np.nanpercentile(eflattened_e_uncal, 99.9))
+                ],
+                dx=1,
+                range=[np.nanpercentile(flattened_e_uncal, 95), np.nanpercentile(flattened_e_uncal, 99.9)],
+            )
+                
+            else: 
+            hist, bins, bar = pgh.get_hist(
+                e_uncal[
+                    (e_uncal > np.nanpercentile(e_uncal, 95))
+                    & (e_uncal < np.nanpercentile(e_uncal, 99.9))
+                ],
+                dx=1,
+                range=[np.nanpercentile(e_uncal, 95), np.nanpercentile(e_uncal, 99.9)],
+            )
 
         guess = 2614.511 / bins[np.nanargmax(hist)]
         full_object_dict[cal_energy_param] = HPGeCalibration(

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -638,13 +638,15 @@ def par_geds_hit_ecal() -> None:
         energy = data[energy_param].to_numpy()
         if isinstance(energy[0], (np.ndarray, list)):
             energy = np.concatenate(e_uncal)
-        
+
         if len(energy) < len(data):
-            print('len(energy) and len(data) are not the same')
-            energy = np.pad(energy, (0, len(data) - len(energy)), constant_values=np.nan)
-        
+            print("len(energy) and len(data) are not the same")
+            energy = np.pad(
+                energy, (0, len(data) - len(energy)), constant_values=np.nan
+            )
+
         if len(data) < len(energy):
-              energy = energy[:len(data)]
+            energy = energy[: len(data)]
 
         data[cal_energy_param] = nb_poly(
             data[energy_param].to_numpy(), full_object_dict[cal_energy_param].pars

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -609,7 +609,8 @@ def par_geds_hit_ecal() -> None:
             debug_mode=kwarg_dict.get("debug_mode", False) | args.debug,
         )
         full_object_dict[cal_energy_param].hpge_get_energy_peaks(
-            e_uncal, etol_kev=5 if det_status == "on" else 20
+            flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal,
+            etol_kev=5 if det_status == "on" else 20
         )
         if 2614.511 not in full_object_dict[cal_energy_param].peaks_kev:
             full_object_dict[cal_energy_param] = HPGeCalibration(
@@ -620,18 +621,18 @@ def par_geds_hit_ecal() -> None:
                 debug_mode=kwarg_dict.get("debug_mode", False),
             )
             full_object_dict[cal_energy_param].hpge_get_energy_peaks(
-                e_uncal, etol_kev=5 if det_status == "on" else 30, n_sigma=2
-            )
+                flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal,
+                etol_kev=5 if det_status == "on" else 30, n_sigma=2
         got_peaks_kev = full_object_dict[cal_energy_param].peaks_kev.copy()
         if det_status != "on":
             full_object_dict[cal_energy_param].hpge_cal_energy_peak_tops(
-                e_uncal,
+                flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal,
                 peaks_kev=got_peaks_kev,
                 update_cal_pars=True,
                 allowed_p_val=0,
             )
         full_object_dict[cal_energy_param].hpge_fit_energy_peaks(
-            e_uncal,
+            flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal,
             peaks_kev=[2614.511],
             peak_pars=pk_pars,
             tail_weight=kwarg_dict.get("tail_weight", 0),
@@ -641,7 +642,7 @@ def par_geds_hit_ecal() -> None:
             bin_width_kev=0.5,
         )
         full_object_dict[cal_energy_param].hpge_fit_energy_peaks(
-            e_uncal,
+            flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal,
             peaks_kev=got_peaks_kev,
             peak_pars=pk_pars,
             tail_weight=kwarg_dict.get("tail_weight", 0),
@@ -701,13 +702,13 @@ def par_geds_hit_ecal() -> None:
             if ~np.isnan(full_object_dict[cal_energy_param].pars).all():
                 param_plot_dict["fwhm_fit"] = full_object_dict[
                     cal_energy_param
-                ].plot_eres_fit(e_uncal)
+                ].plot_eres_fit(flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal)
                 param_plot_dict["cal_fit"] = full_object_dict[
                     cal_energy_param
-                ].plot_cal_fit(e_uncal)
+                ].plot_cal_fit(flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal)
                 param_plot_dict["peak_fits"] = full_object_dict[
                     cal_energy_param
-                ].plot_fits(e_uncal)
+                ].plot_fits(flattened_e_uncal if isinstance(e_uncal[0], (np.ndarray, list)) else e_uncal)
 
                 if "plot_options" in kwarg_dict:
                     for key, item in kwarg_dict["plot_options"].items():

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -605,6 +605,7 @@ def par_geds_hit_ecal() -> None:
             )
             full_object_dict[cal_energy_param].hpge_get_energy_peaks(
                 e_uncal, etol_kev=5 if det_status == "on" else 30, n_sigma=2
+            )
         got_peaks_kev = full_object_dict[cal_energy_param].peaks_kev.copy()
         if det_status != "on":
             full_object_dict[cal_energy_param].hpge_cal_energy_peak_tops(

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -568,22 +568,22 @@ def par_geds_hit_ecal() -> None:
         e_uncal = data.query(selection_string)[energy_param].to_numpy()
         if len(e_uncal) > 0:
             if isinstance(e_uncal[0], (np.ndarray, list)):
-                    e_uncal = np.concatenate(
-                    [arr for arr in e_uncal if len(arr) > 0]
-                )
+                e_uncal = np.concatenate([arr for arr in e_uncal if len(arr) > 0])
             hist, bins, bar = pgh.get_hist(
-                    e_uncal[
-                        (e_uncal > np.nanpercentile(e_uncal, 95))
-                        & (e_uncal < np.nanpercentile(e_uncal, 99.9))
-                    ],
-                    dx=1,
-                    range=[
-                        np.nanpercentile(e_uncal, 95),
-                        np.nanpercentile(e_uncal, 99.9),
-                    ],
-                )
+                e_uncal[
+                    (e_uncal > np.nanpercentile(e_uncal, 95))
+                    & (e_uncal < np.nanpercentile(e_uncal, 99.9))
+                ],
+                dx=1,
+                range=[
+                    np.nanpercentile(e_uncal, 95),
+                    np.nanpercentile(e_uncal, 99.9),
+                ],
+            )
         else:
-            raise ValueError(f"e_uncal should not be empty! energy_param: {energy_param}")
+            raise ValueError(
+                f"e_uncal should not be empty! energy_param: {energy_param}"
+            )
         guess = 2614.511 / bins[np.nanargmax(hist)]
         full_object_dict[cal_energy_param] = HPGeCalibration(
             energy_param,

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -579,8 +579,8 @@ def par_geds_hit_ecal() -> None:
                 dx=1,
                 range=[np.nanpercentile(flattened_e_uncal, 95), np.nanpercentile(flattened_e_uncal, 99.9)],
             )
-                
-            else: 
+
+            else:
             hist, bins, bar = pgh.get_hist(
                 e_uncal[
                     (e_uncal > np.nanpercentile(e_uncal, 95))

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -578,17 +578,17 @@ def par_geds_hit_ecal() -> None:
                 ],
                 dx=1,
                 range=[np.nanpercentile(flattened_e_uncal, 95), np.nanpercentile(flattened_e_uncal, 99.9)],
-            )
+                )
 
             else:
-            hist, bins, bar = pgh.get_hist(
-                e_uncal[
-                    (e_uncal > np.nanpercentile(e_uncal, 95))
-                    & (e_uncal < np.nanpercentile(e_uncal, 99.9))
-                ],
-                dx=1,
-                range=[np.nanpercentile(e_uncal, 95), np.nanpercentile(e_uncal, 99.9)],
-            )
+                hist, bins, bar = pgh.get_hist(
+                    e_uncal[
+                        (e_uncal > np.nanpercentile(e_uncal, 95))
+                        & (e_uncal < np.nanpercentile(e_uncal, 99.9))
+                    ],
+                    dx=1,
+                    range=[np.nanpercentile(e_uncal, 95), np.nanpercentile(e_uncal, 99.9)],
+                )
 
         guess = 2614.511 / bins[np.nanargmax(hist)]
         full_object_dict[cal_energy_param] = HPGeCalibration(

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -572,12 +572,18 @@ def par_geds_hit_ecal() -> None:
                     [arr for arr in e_uncal if len(arr) > 0]
                 )
                 hist, bins, bar = pgh.get_hist(
-                flattened_e_uncal[
-                    (flattened_e_uncal > np.nanpercentile(flattened_e_uncal, 95))
-                    & (flattened_e_uncal < np.nanpercentile(eflattened_e_uncal, 99.9))
-                ],
-                dx=1,
-                range=[np.nanpercentile(flattened_e_uncal, 95), np.nanpercentile(flattened_e_uncal, 99.9)],
+                    flattened_e_uncal[
+                        (flattened_e_uncal > np.nanpercentile(flattened_e_uncal, 95))
+                        & (
+                            flattened_e_uncal
+                            < np.nanpercentile(eflattened_e_uncal, 99.9)
+                        )
+                    ],
+                    dx=1,
+                    range=[
+                        np.nanpercentile(flattened_e_uncal, 95),
+                        np.nanpercentile(flattened_e_uncal, 99.9),
+                    ],
                 )
 
             else:
@@ -587,7 +593,10 @@ def par_geds_hit_ecal() -> None:
                         & (e_uncal < np.nanpercentile(e_uncal, 99.9))
                     ],
                     dx=1,
-                    range=[np.nanpercentile(e_uncal, 95), np.nanpercentile(e_uncal, 99.9)],
+                    range=[
+                        np.nanpercentile(e_uncal, 95),
+                        np.nanpercentile(e_uncal, 99.9),
+                    ],
                 )
 
         guess = 2614.511 / bins[np.nanargmax(hist)]

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -635,6 +635,17 @@ def par_geds_hit_ecal() -> None:
             interp_energy_kev={"Qbb": 2039.0},
         )
 
+        energy = data[energy_param].to_numpy()
+        if isinstance(energy[0], (np.ndarray, list)):
+            energy = np.concatenate(e_uncal)
+        
+        if len(energy) < len(data):
+            print('len(energy) and len(data) are not the same')
+            energy = np.pad(energy, (0, len(data) - len(energy)), constant_values=np.nan)
+        
+        if len(data) < len(energy):
+              energy = energy[:len(data)]
+
         data[cal_energy_param] = nb_poly(
             data[energy_param].to_numpy(), full_object_dict[cal_energy_param].pars
         )

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import argparse
 import copy
+import logging
 import pickle as pkl
 import warnings
 from datetime import datetime
 from pathlib import Path
-import logging
 
 import lgdo.lh5 as lh5
 import matplotlib as mpl
@@ -641,8 +641,10 @@ def par_geds_hit_ecal() -> None:
             energy = np.concatenate(e_uncal)
 
         if len(energy) < len(data):
-            logging.warning('len(energy) and len(data) are not the same')
-            energy = np.pad(energy, (0, len(data) - len(energy)), constant_values=np.nan)
+            logging.warning("len(energy) and len(data) are not the same")
+            energy = np.pad(
+                energy, (0, len(data) - len(energy)), constant_values=np.nan
+            )
 
         if len(data) < len(energy):
             energy = energy[: len(data)]

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -566,6 +566,9 @@ def par_geds_hit_ecal() -> None:
         kwarg_dict["energy_params"], cal_energy_params
     ):
         e_uncal = data.query(selection_string)[energy_param].to_numpy()
+        if len(e_uncal)>0:
+            if (isinstance(e_uncal[0], (np.ndarray, list))):  
+                flattened_e_uncal = np.concatenate([arr for arr in e_uncal if len(arr) > 0])
 
         hist, bins, bar = pgh.get_hist(
             e_uncal[

--- a/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/hit/ecal.py
@@ -6,6 +6,7 @@ import pickle as pkl
 import warnings
 from datetime import datetime
 from pathlib import Path
+import logging
 
 import lgdo.lh5 as lh5
 import matplotlib as mpl
@@ -640,16 +641,14 @@ def par_geds_hit_ecal() -> None:
             energy = np.concatenate(e_uncal)
 
         if len(energy) < len(data):
-            print("len(energy) and len(data) are not the same")
-            energy = np.pad(
-                energy, (0, len(data) - len(energy)), constant_values=np.nan
-            )
+            logging.warning('len(energy) and len(data) are not the same')
+            energy = np.pad(energy, (0, len(data) - len(energy)), constant_values=np.nan)
 
         if len(data) < len(energy):
             energy = energy[: len(data)]
 
         data[cal_energy_param] = nb_poly(
-            data[energy_param].to_numpy(), full_object_dict[cal_energy_param].pars
+            energy, full_object_dict[cal_energy_param].pars
         )
 
         results_dict[cal_energy_param] = get_results_dict(


### PR DESCRIPTION
Edited the par/geds/hit/ecal.py file such that it can calibrate the trapEftpmult value (array of equal sized arrays), that was added in another pull request in the legend-dataflow-config: [Link](https://github.com/legend-exp/legend-dataflow-config/pull/106). 