### PR TITLE
Make sure lazy imported processors are pre-compiled

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -104,7 +104,11 @@ onstart:
     if not workflow.touch:
         shell(
             execenv.execenv_pyexe(config, "python")
-            + "-c 'import dspeed, lgdo, matplotlib, pygama'"
+            + "-c 'import lgdo, matplotlib, pygama'"
+        )
+        shell(
+            execenv.execenv_pyexe(config, "python")
+            + "-c 'from dspeed.processors import *'"
         )
 
         # Log parameter catalogs in validity files


### PR DESCRIPTION
This update https://github.com/legend-exp/dspeed/pull/141 introduced lazy importing to processors. This means `import dspeed` is not sufficient to pre-compile processors to avoid a race condition, so instead add `from dspeed.processors import *`.