### PR TITLE
feat: enable Snakemake benchmark files for DSP-running rules

### DIFF
--- a/dataflow-config.yaml
+++ b/dataflow-config.yaml
@@ -49,6 +49,7 @@ paths:
 
   tmp_plt: $_/generated/tmp/plt
   tmp_log: $_/generated/tmp/log
+  tmp_benchmark: $_/generated/tmp/benchmark
   tmp_filelists: $_/generated/tmp/filelists
   tmp_par: $_/generated/tmp/par
 

--- a/tests/dummy_cycle/config.yaml
+++ b/tests/dummy_cycle/config.yaml
@@ -40,6 +40,7 @@ paths:
 
   tmp_plt: $_/generated/tmp/plt
   tmp_log: $_/generated/tmp/log
+  tmp_benchmark: $_/generated/tmp/benchmark
   tmp_filelists: $_/generated/tmp/filelists
   tmp_par: $_/generated/tmp/par
 

--- a/workflow/rules/dsp.smk
+++ b/workflow/rules/dsp.smk
@@ -29,6 +29,8 @@ rule build_dsp:
         tier_file=patt.get_pattern_tier(config, "dsp", check_in_cycle=check_in_cycle),
     log:
         patt.get_pattern_log(config, "tier_dsp", time),
+    benchmark:
+        patt.get_pattern_benchmark(config, "tier_dsp", time)
     group:
         "tier-dsp"
     threads: get_threads

--- a/workflow/rules/dsp_pars_geds.smk
+++ b/workflow/rules/dsp_pars_geds.smk
@@ -14,6 +14,7 @@ from legenddataflow.methods.patterns import (
     get_pattern_tier,
     get_pattern_log,
     get_pattern_pars,
+    get_pattern_benchmark_channel,
 )
 from legenddataflow.methods.paths import (
     filelist_path,
@@ -38,6 +39,8 @@ rule build_pars_dsp_pz_geds:
         dsp_plots=temp(get_pattern_plts_tmp_channel(config, "dsp", "decay_constant")),
     log:
         get_pattern_log_channel(config, "par_dsp_decay_constant", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "par_dsp_decay_constant", time)
     group:
         "par-dsp"
     resources:
@@ -101,6 +104,8 @@ rule build_pars_evtsel_geds:
         ),
     log:
         get_pattern_log_channel(config, "par_dsp_event_selection", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "par_dsp_event_selection", time)
     group:
         "par-dsp"
     resources:
@@ -168,6 +173,8 @@ rule build_pars_dsp_nopt_geds:
         ),
     log:
         get_pattern_log_channel(config, "par_dsp_noise_optimization", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "par_dsp_noise_optimization", time)
     group:
         "par-dsp"
     resources:
@@ -234,6 +241,8 @@ rule build_pars_dsp_dplms_geds:
         dsp_plots=temp(get_pattern_plts_tmp_channel(config, "dsp", "dplms")),
     log:
         get_pattern_log_channel(config, "pars_dsp_dplms", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "pars_dsp_dplms", time)
     group:
         "par-dsp"
     resources:
@@ -303,6 +312,8 @@ rule build_pars_dsp_eopt_geds:
         dsp_plots=temp(get_pattern_plts_tmp_channel(config, "dsp", "eopt")),
     log:
         get_pattern_log_channel(config, "pars_dsp_eopt", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "pars_dsp_eopt", time)
     group:
         "par-dsp"
     resources:

--- a/workflow/rules/dsp_pars_spms.smk
+++ b/workflow/rules/dsp_pars_spms.smk
@@ -18,6 +18,8 @@ rule build_pars_dsp_tau_spms:
         patt.get_pattern_pars(config, "dsp", name="spms", datatype="{datatype}"),
     log:
         patt.get_pattern_log(config, "pars_spms", time),
+    benchmark:
+        patt.get_pattern_benchmark(config, "pars_spms", time)
     wildcard_constraints:
         datatype=r"\b(?!cal\b|xtc\b)\w+\b",
     group:

--- a/workflow/rules/psp.smk
+++ b/workflow/rules/psp.smk
@@ -11,6 +11,7 @@ from legenddataflow.methods.patterns import (
     get_pattern_tier,
     get_pattern_log,
     get_pattern_pars,
+    get_pattern_benchmark,
 )
 from legenddataflow.methods.paths import config_path
 from legenddataflowscripts.workflow import execenv_pyexe
@@ -38,6 +39,8 @@ rule build_psp:
         tier_file=get_pattern_tier(config, "psp", check_in_cycle=check_in_cycle),
     log:
         get_pattern_log(config, "tier_psp", time),
+    benchmark:
+        get_pattern_benchmark(config, "tier_psp", time)
     group:
         "tier-dsp"
     threads: get_threads

--- a/workflow/rules/psp_pars_geds.smk
+++ b/workflow/rules/psp_pars_geds.smk
@@ -12,6 +12,7 @@ from legenddataflow.methods.patterns import (
     get_pattern_log,
     get_pattern_pars,
     get_pattern_tier,
+    get_pattern_benchmark_channel,
 )
 from legenddataflow.methods.paths import config_path
 from legenddataflowscripts.workflow import execenv_pyexe, set_last_rule_name
@@ -306,6 +307,8 @@ rule build_par_psp_fallback:
         psp_plots=temp(get_pattern_plts_tmp_channel(config, "psp", "eopt")),
     log:
         get_pattern_log_channel(config, "pars_psp", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "pars_psp", time)
     group:
         "par-psp"
     resources:
@@ -354,6 +357,8 @@ rule build_pars_psp_dplms_geds_fallback:
         plots=temp(get_pattern_plts_tmp_channel(config, "psp")),
     log:
         get_pattern_log_channel(config, "pars_psp_dplms", time),
+    benchmark:
+        get_pattern_benchmark_channel(config, "pars_psp_dplms", time)
     group:
         "par-psp"
     resources:

--- a/workflow/src/legenddataflow/methods/paths.py
+++ b/workflow/src/legenddataflow/methods/paths.py
@@ -97,5 +97,9 @@ def tmp_log_path(setup):
     return setup["paths"]["tmp_log"]
 
 
+def tmp_benchmark_path(setup):
+    return setup["paths"]["tmp_benchmark"]
+
+
 def filelist_path(setup):
     return setup["paths"]["tmp_filelists"]

--- a/workflow/src/legenddataflow/methods/patterns.py
+++ b/workflow/src/legenddataflow/methods/patterns.py
@@ -16,6 +16,7 @@ from .paths import (
     tier_daq_path,
     tier_path,
     tier_raw_blind_path,
+    tmp_benchmark_path,
     tmp_log_path,
     tmp_par_path,
     tmp_plts_path,
@@ -340,4 +341,32 @@ def get_pattern_log_concat(setup, processing_step, time):
         / time
         / processing_step
         / ("{experiment}-{period}-{run}-{datatype}-" + processing_step + ".log")
+    )
+
+
+def get_pattern_benchmark(setup, processing_step, time):
+    return (
+        Path(f"{tmp_benchmark_path(setup)}")
+        / time
+        / processing_step
+        / (
+            "{experiment}-{period}-{run}-{datatype}-{timestamp}-"
+            + processing_step
+            + ".tsv"
+        )
+    )
+
+
+def get_pattern_benchmark_channel(setup, processing_step, time, datatype="cal"):
+    return (
+        Path(f"{tmp_benchmark_path(setup)}")
+        / time
+        / processing_step
+        / (
+            "{experiment}-{period}-{run}-"
+            + datatype
+            + "-{timestamp}-{channel}-"
+            + processing_step
+            + ".tsv"
+        )
     )

--- a/workflow/src/legenddataflow/scripts/par/geds/pht/fast.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/pht/fast.py
@@ -257,7 +257,10 @@ def par_geds_pht_fast() -> None:
     save_dict_to_files(
         sorted(args.hit_pars),
         {
-            tstamp: {"pars": {"operations":cal_dicts[tstamp]}, "results": results_dicts[tstamp]}
+            tstamp: {
+                "pars": {"operations": cal_dicts[tstamp]},
+                "results": results_dicts[tstamp],
+            }
             for tstamp in cal_dicts
         },
     )


### PR DESCRIPTION
## Summary
- Add `benchmark:` directives to every rule that executes DSP processing (tier build and parameter generation, geds and spms, dsp and psp). Snakemake will write per-rule wall-time / memory TSVs alongside the existing logs.
- New plumbing: `tmp_benchmark` path, `tmp_benchmark_path()` helper, and `get_pattern_benchmark` / `get_pattern_benchmark_channel` mirroring the existing log helpers.
- Drive-by: a small formatting tweak to `pht/fast.py` (`save_dict_to_files` call).

## Rules instrumented
- `dsp.smk` → `build_dsp`
- `psp.smk` → `build_psp`
- `dsp_pars_spms.smk` → `build_pars_dsp_tau_spms`
- `dsp_pars_geds.smk` → `build_pars_dsp_pz_geds`, `build_pars_evtsel_geds`, `build_pars_dsp_nopt_geds`, `build_pars_dsp_dplms_geds`, `build_pars_dsp_eopt_geds`
- `psp_pars_geds.smk` → `build_par_psp_fallback`, `build_pars_psp_dplms_geds_fallback`

The SVM training rules (`build_svm_dsp_geds`, `build_pars_dsp_svm_geds`, and PSP svm equivalents) are intentionally skipped — they don't run DSP on data.

## Test plan
- [x] `pytest tests/` passes
- [x] Snakemake parses every rule body (workflow loads up to a pre-existing dummy-cycle catalog issue unrelated to this change)
- [ ] On a real production run: confirm `generated/tmp/benchmark/<time>/<step>/*.tsv` files appear and contain sensible numbers