### PR TITLE
feat: symlink overridden paths to canonical default locations on startup

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -123,42 +123,21 @@ onstart:
             + "-c 'from dspeed.processors import *'"
         )
 
-        # Log parameter catalogs in validity files
-    hit_par_cat_file = Path(paths.pars_path(config)) / "hit" / "validity.yaml"
-    if hit_par_cat_file.is_file():
-        hit_par_cat_file.unlink()
-    try:
-        Path(hit_par_cat_file).parent.mkdir(parents=True, exist_ok=True)
-        hit_par_catalog.write_to(hit_par_cat_file)
-    except NameError:
-        logger.warning("No hit parameter catalog found")
-
-    pht_par_cat_file = Path(paths.pars_path(config)) / "pht" / "validity.yaml"
-    if pht_par_cat_file.is_file():
-        pht_par_cat_file.unlink()
-    try:
-        Path(pht_par_cat_file).parent.mkdir(parents=True, exist_ok=True)
-        pht_par_catalog.write_to(pht_par_cat_file)
-    except NameError:
-        logger.warning("No pht parameter catalog found")
-
-    dsp_par_cat_file = Path(paths.pars_path(config)) / "dsp" / "validity.yaml"
-    if dsp_par_cat_file.is_file():
-        dsp_par_cat_file.unlink()
-    try:
-        Path(dsp_par_cat_file).parent.mkdir(parents=True, exist_ok=True)
-        dsp_par_catalog.write_to(dsp_par_cat_file)
-    except NameError:
-        logger.warning("No dsp parameter catalog found")
-
-    psp_par_cat_file = Path(paths.pars_path(config)) / "psp" / "validity.yaml"
-    if psp_par_cat_file.is_file():
-        psp_par_cat_file.unlink()
-    try:
-        Path(psp_par_cat_file).parent.mkdir(parents=True, exist_ok=True)
-        psp_par_catalog.write_to(psp_par_cat_file)
-    except NameError:
-        logger.warning("No psp parameter catalog found")
+    # Log parameter catalogs in validity files; skip tiers whose par path
+    # has been redirected outside the current production tree
+    for _tier in ["dsp", "hit", "psp", "pht"]:
+        if os.path.abspath(paths.get_pars_path(config, _tier)) != os.path.abspath(
+            Path(paths.pars_path(config)) / _tier
+        ):
+            continue
+        _cat_file = Path(paths.pars_path(config)) / _tier / "validity.yaml"
+        if _cat_file.is_file():
+            _cat_file.unlink()
+        try:
+            _cat_file.parent.mkdir(parents=True, exist_ok=True)
+            globals()[f"{_tier}_par_catalog"].write_to(_cat_file)
+        except KeyError:
+            logger.warning("No %s parameter catalog found", _tier)
 
 
 onsuccess:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -101,6 +101,7 @@ localrules:
 
 onstart:
     logger.info("INFO: starting workflow")
+    paths.link_external_paths(config, workflow.basedir, logger=logger)
 
     # Make sure some packages are initialized before we begin to avoid race conditions
     # https://numba.readthedocs.io/en/stable/developer/caching.html#cache-sharing

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -101,7 +101,7 @@ localrules:
 
 onstart:
     logger.info("INFO: starting workflow")
-    paths.link_external_paths(config, workflow.basedir, logger=logger)
+    paths.link_external_paths(config, logger=logger)
 
     # Make sure some packages are initialized before we begin to avoid race conditions
     # https://numba.readthedocs.io/en/stable/developer/caching.html#cache-sharing

--- a/workflow/src/legenddataflow/methods/paths.py
+++ b/workflow/src/legenddataflow/methods/paths.py
@@ -8,9 +8,6 @@ import logging
 import os
 from pathlib import Path
 
-import yaml
-from legenddataflowscripts.workflow import subst_vars
-
 
 def sandbox_path(setup):
     if "sandbox_path" in setup["paths"]:
@@ -112,38 +109,38 @@ def filelist_path(setup):
     return setup["paths"]["tmp_filelists"]
 
 
-# leaf-level paths eligible for symlinking (parent dirs 'tier' and 'par' are
-# intentionally excluded to avoid parent/child symlink conflicts)
-_SYMLINK_CANDIDATES = (
-    "tier_daq",
-    "tier_raw",
-    "tier_tcm",
-    "tier_dsp",
-    "tier_hit",
-    "tier_ann",
-    "tier_evt",
-    "tier_psp",
-    "tier_pht",
-    "tier_pan",
-    "tier_pet",
-    "tier_skm",
-    "tier_raw_blind",
-    "par_raw",
-    "par_tcm",
-    "par_dsp",
-    "par_hit",
-    "par_evt",
-    "par_psp",
-    "par_pht",
-    "par_pet",
-    "plt",
-    "metadata",
-)
+# Maps each paths.<key> candidate to its canonical default location relative to
+# the production root (CWD).  Parent keys 'tier' and 'par' are intentionally
+# excluded to avoid parent/child symlink conflicts.
+_DEFAULT_SUBPATHS: dict[str, str] = {
+    "tier_daq": "generated/tier/daq",
+    "tier_raw": "generated/tier/raw",
+    "tier_tcm": "generated/tier/tcm",
+    "tier_dsp": "generated/tier/dsp",
+    "tier_hit": "generated/tier/hit",
+    "tier_ann": "generated/tier/ann",
+    "tier_evt": "generated/tier/evt",
+    "tier_psp": "generated/tier/psp",
+    "tier_pht": "generated/tier/pht",
+    "tier_pan": "generated/tier/pan",
+    "tier_pet": "generated/tier/pet",
+    "tier_skm": "generated/tier/skm",
+    "tier_raw_blind": "generated/tier/raw-blind",
+    "par_raw": "generated/par/raw",
+    "par_tcm": "generated/par/tcm",
+    "par_dsp": "generated/par/dsp",
+    "par_hit": "generated/par/hit",
+    "par_evt": "generated/par/evt",
+    "par_psp": "generated/par/psp",
+    "par_pht": "generated/par/pht",
+    "par_pet": "generated/par/pet",
+    "plt": "generated/plt",
+    "metadata": "inputs",
+}
 
 
 def link_external_paths(
     config,
-    workflow_basedir: str | Path,
     *,
     logger: logging.Logger | None = None,
 ) -> None:
@@ -155,10 +152,8 @@ def link_external_paths(
     the canonical default location so the ``generated/`` tree maintains a
     consistent layout.
 
-    The canonical defaults are read from the ``dataflow-config.yaml`` found at
-    ``<workflow_basedir>/../dataflow-config.yaml``, with ``$_`` substituted by
-    the current working directory.  The call is a safe no-op when that file does
-    not exist.
+    The canonical default for each key is derived from :data:`_DEFAULT_SUBPATHS`
+    relative to the current working directory (the production root).
 
     For each candidate key:
 
@@ -170,30 +165,16 @@ def link_external_paths(
     Real directories at the default location are never modified.
     """
     log_ = logger if logger is not None else logging.getLogger(__name__)
-    template = Path(workflow_basedir).parent / "dataflow-config.yaml"
-    if not template.is_file():
-        return
-
-    default_cfg = yaml.safe_load(template.read_text())
-    if not isinstance(default_cfg, dict):
-        return
-
-    subst_vars(
-        default_cfg,
-        var_values={"_": str(Path.cwd().resolve())},
-        ignore_missing=True,
-    )
-    default_paths = default_cfg.get("paths", {})
     config_paths = config.get("paths", {})
+    root = Path.cwd()
 
-    for key in _SYMLINK_CANDIDATES:
+    for key, subpath in _DEFAULT_SUBPATHS.items():
         current_str = config_paths.get(key)
-        default_str = default_paths.get(key)
-        if current_str is None or default_str is None:
+        if current_str is None:
             continue
 
         current = Path(current_str)
-        default = Path(default_str)
+        default = root / subpath
 
         # os.path.abspath (not Path.resolve) on purpose: don't follow symlinks
         if os.path.abspath(current) == os.path.abspath(default):  # noqa: PTH100
@@ -225,6 +206,6 @@ def link_external_paths(
             )
 
         rel = Path(os.path.relpath(current, start=default.parent))
+        log_.info("symlinking %s -> %s", default, rel)
         default.parent.mkdir(parents=True, exist_ok=True)
         default.symlink_to(rel, target_is_directory=True)
-        log_.info("symlinked %s -> %s", default, rel)

--- a/workflow/src/legenddataflow/methods/paths.py
+++ b/workflow/src/legenddataflow/methods/paths.py
@@ -4,6 +4,13 @@ This module contains resolvers for the config.json dictionary
 
 from __future__ import annotations
 
+import logging
+import os
+from pathlib import Path
+
+import yaml
+from legenddataflowscripts.workflow import subst_vars
+
 
 def sandbox_path(setup):
     if "sandbox_path" in setup["paths"]:
@@ -103,3 +110,121 @@ def tmp_benchmark_path(setup):
 
 def filelist_path(setup):
     return setup["paths"]["tmp_filelists"]
+
+
+# leaf-level paths eligible for symlinking (parent dirs 'tier' and 'par' are
+# intentionally excluded to avoid parent/child symlink conflicts)
+_SYMLINK_CANDIDATES = (
+    "tier_daq",
+    "tier_raw",
+    "tier_tcm",
+    "tier_dsp",
+    "tier_hit",
+    "tier_ann",
+    "tier_evt",
+    "tier_psp",
+    "tier_pht",
+    "tier_pan",
+    "tier_pet",
+    "tier_skm",
+    "tier_raw_blind",
+    "par_raw",
+    "par_tcm",
+    "par_dsp",
+    "par_hit",
+    "par_evt",
+    "par_psp",
+    "par_pht",
+    "par_pet",
+    "plt",
+    "metadata",
+)
+
+
+def link_external_paths(
+    config,
+    workflow_basedir: str | Path,
+    *,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Symlink overridden paths back into their canonical default locations.
+
+    When a ``paths.<key>`` entry in ``dataflow-config.yaml`` has been set to a
+    location outside the current production tree (e.g. reusing the ``tier_dsp``
+    output from another production), this function creates a relative symlink at
+    the canonical default location so the ``generated/`` tree maintains a
+    consistent layout.
+
+    The canonical defaults are read from the ``dataflow-config.yaml`` found at
+    ``<workflow_basedir>/../dataflow-config.yaml``, with ``$_`` substituted by
+    the current working directory.  The call is a safe no-op when that file does
+    not exist.
+
+    For each candidate key:
+
+    - if the configured path already equals the default, any stale symlink at
+      the default location is removed;
+    - otherwise a relative symlink is created (or refreshed) at the default
+      location pointing to the configured path.
+
+    Real directories at the default location are never modified.
+    """
+    log_ = logger if logger is not None else logging.getLogger(__name__)
+    template = Path(workflow_basedir).parent / "dataflow-config.yaml"
+    if not template.is_file():
+        return
+
+    default_cfg = yaml.safe_load(template.read_text())
+    if not isinstance(default_cfg, dict):
+        return
+
+    subst_vars(
+        default_cfg,
+        var_values={"_": str(Path.cwd().resolve())},
+        ignore_missing=True,
+    )
+    default_paths = default_cfg.get("paths", {})
+    config_paths = config.get("paths", {})
+
+    for key in _SYMLINK_CANDIDATES:
+        current_str = config_paths.get(key)
+        default_str = default_paths.get(key)
+        if current_str is None or default_str is None:
+            continue
+
+        current = Path(current_str)
+        default = Path(default_str)
+
+        # os.path.abspath (not Path.resolve) on purpose: don't follow symlinks
+        if os.path.abspath(current) == os.path.abspath(default):  # noqa: PTH100
+            if default.is_symlink():
+                default.unlink()
+            continue
+
+        if default.is_symlink():
+            if (default.parent / default.readlink()).resolve() == current.resolve():
+                continue
+            default.unlink()
+        elif default.exists():
+            log_.warning(
+                "%s is an existing non-symlink path; ignoring override -> %s",
+                default,
+                current,
+            )
+            continue
+
+        if not current.exists():
+            log_.warning(
+                "override target %s does not exist; %s will be a broken symlink",
+                current,
+                default,
+            )
+        elif not current.is_dir():
+            log_.warning(
+                "override target %s is not a directory; linking anyway", current
+            )
+
+        rel = Path(os.path.relpath(current, start=default.parent))
+        default.parent.mkdir(parents=True, exist_ok=True)
+        default.symlink_to(rel, target_is_directory=True)
+        log_.info("symlinked %s -> %s", default, rel)

--- a/workflow/src/legenddataflow/scripts/flow/complete_run.py
+++ b/workflow/src/legenddataflow/scripts/flow/complete_run.py
@@ -236,5 +236,9 @@ if snakemake.params.setup.get("check_log_files", True):
         snakemake.output.gen_output,
         warning_file=snakemake.output.warning_log,
     )
+else:
+    Path(snakemake.output.summary_log).parent.mkdir(parents=True, exist_ok=True)
+    Path(snakemake.output.summary_log).touch()
+    Path(snakemake.output.warning_log).touch()
 
 Path(snakemake.output.gen_output).touch()


### PR DESCRIPTION
## Summary

- Adds `link_external_paths()` to `legenddataflow/methods/paths.py`, called in `onstart` via `paths.link_external_paths(config, workflow.basedir, logger=logger)`
- When a `paths.<key>` in `dataflow-config.yaml` points outside the current production tree, a relative symlink is created at the canonical default location (e.g. `generated/tier/dsp -> /other/prod/generated/tier/dsp`) so the `generated/` layout stays consistent regardless of overrides
- Stale symlinks at default locations are cleaned up automatically when overrides are removed
- Real directories at default locations are never modified
- Mirrors the identical strategy in `legend-simflows` (`legendsimflow.utils.link_external_paths`)
- Candidate keys: all leaf-level tier (`tier_*`, `tier_raw_blind`) and par (`par_*`) paths, plus `plt` and `metadata`; parent dirs `tier` and `par` are excluded to avoid parent/child symlink conflicts
- Validity-file writes for par catalogs are skipped when the corresponding `par_<tier>` path is redirected outside the current production tree, to avoid writing into shared/read-only external directories

## Test plan

- [ ] Run workflow with all paths at defaults — no symlinks created, no errors
- [ ] Override one path (e.g. `tier_dsp`) to an external directory — symlink appears at `generated/tier/dsp`
- [ ] Remove the override — stale symlink is cleaned up on next run
- [ ] Override a path to a non-existent directory — warning logged, broken symlink created
- [ ] Override `par_pht` — validity file is not written to the external par directory