### PR TITLE
chore: bump dependencies and migrate to legend-lh5io

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "legend-pydataobj==2.0.2",
     "legend-lh5io==0.2.6",
     "legend-daq2lh5==1.6.3",
-    "legend-dataflow-scripts==0.3.1",
+    "legend-dataflow-scripts==0.3.2",
     "pip",
     "snakemake-logger-plugin-rich",
     "snakemake-logger-plugin-snkmt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "dspeed==2.1.4",
     "pylegendmeta==1.4.4",
     "legend-pydataobj==2.0.2",
+    "legend-lh5io==0.2.6",
     "legend-daq2lh5==1.6.3",
     "legend-dataflow-scripts==0.3.1",
     "pip",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,11 @@ dynamic = ["version"]
 
 dependencies = [
     "colorlog",
-    "dbetto==1.2.4",
-    "pygama==2.3.8",
-    "dspeed==2.1.2",
-    "pylegendmeta==1.3.1",
-    "legend-pydataobj==1.17.2",
+    "dbetto==1.3.6",
+    "pygama==2.3.10",
+    "dspeed==2.1.4",
+    "pylegendmeta==1.4.4",
+    "legend-pydataobj==2.0.2",
     "legend-daq2lh5==1.6.3",
     "legend-dataflow-scripts==0.3.1",
     "pip",

--- a/workflow/src/legenddataflow/scripts/flow/merge_channels.py
+++ b/workflow/src/legenddataflow/scripts/flow/merge_channels.py
@@ -6,8 +6,8 @@ import pickle as pkl
 import shelve
 from pathlib import Path
 
+import lh5
 from dbetto.catalog import Props
-from lgdo import lh5
 
 from legenddataflow.methods import ChannelProcKey
 

--- a/workflow/src/legenddataflow/scripts/flow/merge_in_channel.py
+++ b/workflow/src/legenddataflow/scripts/flow/merge_in_channel.py
@@ -4,8 +4,8 @@ import argparse
 import pickle as pkl
 from pathlib import Path
 
+import lh5
 from dbetto.catalog import Props
-from lgdo import lh5
 from lgdo.types import Struct
 
 from legenddataflow.methods import ChannelProcKey

--- a/workflow/src/legenddataflow/scripts/par/geds/pht/qc_phy.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/pht/qc_phy.py
@@ -7,12 +7,12 @@ import re
 import warnings
 from pathlib import Path
 
+import lh5
 import numpy as np
 from dbetto import TextDB
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log, convert_dict_np_to_float
-from lgdo import lh5
-from lgdo.lh5 import ls
+from lh5 import ls
 from pygama.pargen.data_cleaning import (
     generate_cut_classifiers,
     get_keys,

--- a/workflow/src/legenddataflow/scripts/par/geds/psp/dplms.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/psp/dplms.py
@@ -4,11 +4,12 @@ import argparse
 import time
 from pathlib import Path
 
+import lh5
 import numpy as np
 import pygama.math.distributions as pmd  # noqa: F401
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log
-from lgdo import Array, Table, WaveformTable, lh5
+from lgdo import Array, Table, WaveformTable
 from pygama.evt.build_tcm import _concat_tables
 from pygama.pargen.data_cleaning import generate_cuts
 from pygama.pargen.dplms_ge_dict import dplms_ge_dict

--- a/workflow/src/legenddataflow/scripts/par/geds/raw/blindcal.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/raw/blindcal.py
@@ -10,13 +10,13 @@ import argparse
 import pickle as pkl
 from pathlib import Path
 
+import lh5
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from dbetto import TextDB
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log
-from lgdo import lh5
 from pygama.pargen.energy_cal import HPGeCalibration
 
 mpl.use("agg")

--- a/workflow/src/legenddataflow/scripts/par/geds/raw/blindcheck.py
+++ b/workflow/src/legenddataflow/scripts/par/geds/raw/blindcheck.py
@@ -12,6 +12,7 @@ import argparse
 import pickle as pkl
 from pathlib import Path
 
+import lh5
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numexpr as ne
@@ -20,7 +21,6 @@ from dbetto import TextDB
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log
 from legendmeta import LegendMetadata
-from lgdo import lh5
 from pygama.math.histogram import get_hist
 from pygama.pargen.energy_cal import get_i_local_maxima
 

--- a/workflow/src/legenddataflow/scripts/par/spms/dsp/trigger_threshold.py
+++ b/workflow/src/legenddataflow/scripts/par/spms/dsp/trigger_threshold.py
@@ -4,11 +4,11 @@ import argparse
 from pathlib import Path
 
 import hist
+import lh5
 import numpy as np
 from dbetto import AttrsDict, Props, TextDB, utils
 from dspeed import build_dsp
 from legenddataflowscripts.utils import build_log, cfgtools
-from lgdo import lh5
 
 
 def get_channel_trg_thr(df_configs, sipm_name, dsp_db, raw_file, raw_table_name, log):

--- a/workflow/src/legenddataflow/scripts/tier/evt.py
+++ b/workflow/src/legenddataflow/scripts/tier/evt.py
@@ -4,11 +4,11 @@ import argparse
 import json
 from pathlib import Path
 
+import lh5
 import numpy as np
 from dbetto import AttrsDict, Props, TextDB
 from legenddataflowscripts.utils import build_log
 from legendmeta import LegendMetadata
-from lgdo import lh5
 from lgdo.types import Array
 from pygama.evt import build_evt
 

--- a/workflow/src/legenddataflow/scripts/tier/raw_blind.py
+++ b/workflow/src/legenddataflow/scripts/tier/raw_blind.py
@@ -16,12 +16,12 @@ import argparse
 import time
 
 import hdf5plugin
+import lh5
 import numexpr as ne
 import numpy as np
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import alias_table, build_log
 from legendmeta import LegendMetadata, TextDB
-from lgdo import lh5
 
 filter_map = {
     "zstd": hdf5plugin.Zstd(),

--- a/workflow/src/legenddataflow/scripts/tier/skm.py
+++ b/workflow/src/legenddataflow/scripts/tier/skm.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import argparse
 
 import awkward as ak
+import lh5
 from dbetto import TextDB
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log
-from lgdo import lh5
 from lgdo.types import Array, Struct, Table, VectorOfVectors
 
 

--- a/workflow/src/legenddataflow/scripts/tier/tcm.py
+++ b/workflow/src/legenddataflow/scripts/tier/tcm.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import lh5
 from daq2lh5.orca import orca_flashcam
 from dbetto import AttrsDict, TextDB
 from dbetto.catalog import Props
 from legenddataflowscripts.utils import build_log
-from lgdo import lh5
 from pygama.evt.build_tcm import build_tcm
 
 


### PR DESCRIPTION
## Summary

- Bump core dependencies to latest versions: dbetto 1.3.6, pygama 2.3.10, dspeed 2.1.4, pylegendmeta 1.4.4, legend-pydataobj 2.0.2
- Add `legend-lh5io==0.2.6` (lh5 I/O has moved out of `legend-pydataobj>=2` into its own package)
- Migrate all `from lgdo import lh5` → `import lh5` and `from lgdo.lh5 import …` → `from lh5 import …` across the workflow scripts

## Compatibility notes

- **dbetto**: UTC fix in `str_to_datetime` is a bug fix (the `Z` suffix was previously silently ignored); no behavioural change for this dataflow since all timestamps are strings in `YYYYmmddTHHMMSSZ` format
- **pylegendmeta**: `channelmap()` now returns a readonly `AttrsDict` — all usages in this repo are read-only; `legendmeta.catalog` shim removed but dataflow imports from `dbetto.catalog` directly