### PR TITLE
add --notemp to the profiles

### DIFF
--- a/workflow/profiles/lngs/config.yaml
+++ b/workflow/profiles/lngs/config.yaml
@@ -6,6 +6,7 @@ configfile: dataflow-config.yaml
 snakefile: ./workflow/Snakefile
 keep-going: true
 rerun-incomplete: true
+notemp: true
 config:
   - system=lngs
   - XDG_CACHE_HOME=.snakemake/cache

--- a/workflow/profiles/sator/config.yaml
+++ b/workflow/profiles/sator/config.yaml
@@ -4,5 +4,6 @@ configfile: dataflow-config.yaml
 snakefile: ./workflow/Snakefile
 keep-going: true
 rerun-incomplete: true
+notemp: true
 config:
   - system=sator


### PR DESCRIPTION
some of the rules that generate tmp files take quite long and can be very frustrating to rerun everything when developing the data production. i think it's perfectly fine to keep these files on disk by default
