### PR TITLE
feat: pixi-managed software environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,21 @@ jobs:
         run: |
           python -m pytest
 
+  unit-tests-pixi:
+    name: Run units tests in a pixi environment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Pixi
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          environments: test
+
+      - name: Run unit tests
+        run: |
+          pixi run -e test test
+
   run-dataflow:
     if: github.event.pull_request.head.repo.fork == false
     name: Run the Snakemake workflow

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pytest
 
   unit-tests-pixi:
-    name: Run units tests in a pixi environment
+    name: Run unit tests in a pixi environment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ venv.bak/
 .mypy_cache/
 
 docs/source/api
+
+# pixi environments (lock file is not committed, following legend-simflow)
+.pixi/
+pixi.lock

--- a/dataflow-config.yaml
+++ b/dataflow-config.yaml
@@ -67,6 +67,10 @@ table_format:
   skm: "{grp}/skm"
   tcm: hardware_tcm_1
 
+# NOTE: the execenv block below is only needed for container-based setups
+# installed with 'dataflow install'. Cycles whose software environment is
+# managed by pixi (see [tool.pixi] in pyproject.toml) can drop it entirely:
+# all commands then run directly in the ambient pixi environment.
 execenv:
   bare:
     env:

--- a/docs/source/user_manual.rst
+++ b/docs/source/user_manual.rst
@@ -7,11 +7,40 @@ Installation
 Prerequisites
 -------------
 
-- Python 3.11 or later
-- `uv <https://docs.astral.sh/uv/>`_ (or another virtual environment manager)
+- `pixi <https://pixi.sh>`_ (recommended) or Python 3.11 or later with
+  `uv <https://docs.astral.sh/uv/>`_ (or another virtual environment manager)
 - Access to the LEGEND metadata repository
 
-Clone and install the package:
+Installation with pixi (recommended)
+------------------------------------
+
+All software versions (including the conda-forge packages that would otherwise
+require a container image) are specified in ``pyproject.toml``. With
+`pixi <https://pixi.sh>`_ installed, the whole environment is created with:
+
+.. code-block:: bash
+
+   git clone https://github.com/legend-exp/legend-dataflow.git
+   cd legend-dataflow
+   pixi install
+
+Enter the environment with ``pixi shell``, or use the provided tasks without
+entering a shell:
+
+- ``pixi run prod [--profile <name>]`` — run the workflow with a Snakemake profile
+- ``pixi run dry`` — preview what Snakemake would do without executing
+- ``pixi run snakemake [ARGS]`` — pass arbitrary arguments directly to Snakemake
+- ``pixi run -e test test`` — run the unit test suite
+
+When the software environment is managed by pixi, the ``execenv:`` section of
+``dataflow-config.yaml`` can be dropped entirely: all workflow commands then run
+directly in the ambient pixi environment and no container layer or per-cycle
+virtualenv (``dataflow install``) is needed.
+
+Installation with uv
+--------------------
+
+Alternatively, create a plain Python virtual environment:
 
 .. code-block:: bash
 
@@ -26,8 +55,8 @@ dependencies. For production use, omit ``[dev]``.
 
 
 
-Installing the software environment
-------------------------------------
+Installing the software environment (legacy, container sites)
+-------------------------------------------------------------
 
 All software versions are stored in the ``pyproject.toml`` file. These can be releases of the
 various packages e.g. ``dbetto==1.2.4`` or local versions ``dbetto @  file:///${PROJECT_ROOT}/dbetto``.
@@ -42,6 +71,12 @@ below), install the execution environment:
 where ``<host>`` is one of the execution environments defined in the config (e.g.
 ``bare``, ``lngs``, ``sator``, ``nersc``). This installs all required software into
 ``.snakemake/legend-dataflow/venv``.
+
+.. note::
+
+   ``dataflow install`` (and the ``execenv:`` container machinery it relies on)
+   is deprecated in favour of the pixi-based setup above, which provides the
+   full software stack from conda-forge without containers.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,60 @@ exclude = ["generated", "inputs", "software", "workflow"]
 [tool.uv]
 default-groups = []
 
+[tool.pixi.workspace]
+# bioconda provides the snakemake packages
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64"]
+
+# NOTE: non-conda dependencies will be installed from pypi
+[tool.pixi.pypi-dependencies]
+legend_dataflow = { path = ".", editable = true }
+# none of these are on conda-forge
+legend-daq2lh5 = "==1.6.3"
+legend-dataflow-scripts = "==0.3.3"
+snakemake-logger-plugin-rich = "*"
+snakemake-logger-plugin-snkmt = "*"
+
+# FIXME: remove when https://github.com/prefix-dev/pixi/issues/532 is closed
+[tool.pixi.dependencies]
+python = "3.12.*"
+colorlog = "*"
+dbetto = "==1.3.7"
+pygama = "==2.4.1"
+dspeed = "==2.1.4"
+pylegendmeta = "==1.4.4"
+legend-pydataobj = "==2.0.2"
+legend-lh5io = "==0.2.6"
+pip = "*"
+
+# execution (the runprod extra)
+pygments = "*"
+snakemake = "==9.9.0"
+
+# with pixi providing the full software environment there is no need for the
+# execenv container layer: these replace the env vars from the execenv config
+[tool.pixi.activation.env]
+LGDO_BOUNDSCHECK = "false"
+DSPEED_BOUNDSCHECK = "false"
+PYGAMA_PARALLEL = "false"
+PYGAMA_FASTMATH = "false"
+TQDM_DISABLE = "true"
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }
+
+[tool.pixi.tasks]
+snakemake = "snakemake"
+dry = "snakemake --dry-run"
+
+[tool.pixi.tasks.prod]
+cmd = "snakemake --workflow-profile workflow/profiles/{{ profile }}"
+args = [{ arg = "profile", default = "default" }]
+
+[tool.pixi.feature.test.tasks]
+test = "pytest"
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ default-groups = []
 [tool.pixi.workspace]
 # bioconda provides the snakemake packages
 channels = ["conda-forge", "bioconda"]
-platforms = ["linux-64"]
+platforms = ["linux-64", "osx-64", "osx-arm64"]
 
 # NOTE: non-conda dependencies will be installed from pypi
 [tool.pixi.pypi-dependencies]
@@ -164,6 +164,8 @@ TQDM_DISABLE = "true"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }
+# the "test" feature maps to the [project.optional-dependencies] test extra,
+# so pytest & co are pulled in automatically
 test = { features = ["test"], solve-group = "default" }
 
 [tool.pixi.tasks]


### PR DESCRIPTION
Closes #135 (first stage).

Adds a [`pixi`](https://pixi.sh)-managed software environment to the production cycle, modeled on [legend-simflow](https://github.com/legend-exp/legend-simflow)'s setup, as the path towards removing the execenv container machinery.

## Changes

- **`[tool.pixi]` workspace in `pyproject.toml`**: conda-forge + bioconda channels (linux-64); `[tool.pixi.dependencies]` mirroring the pinned pypi dependencies with the exact production pins (`pygama==2.4.1`, `dspeed==2.1.4`, `snakemake==9.9.0`, …); `[tool.pixi.pypi-dependencies]` with the repo itself editable plus the four packages not on conda-forge (`legend-daq2lh5`, `legend-dataflow-scripts`, both snakemake logger plugins); `default`/`test` environments on one solve-group; `snakemake` / `dry` / `prod [--profile <name>]` / `test` tasks.
- **`[tool.pixi.activation.env]`** reproduces the execenv "bare" env vars (`LGDO_BOUNDSCHECK`, `DSPEED_BOUNDSCHECK`, `PYGAMA_PARALLEL`, `PYGAMA_FASTMATH`, `TQDM_DISABLE`) — a pixi-managed cycle needs no `execenv:` section and no containers. With the companion legend-exp/legend-dataflow-scripts#45 change, `execenv_pyexe` then returns bare console-script names that resolve from the pixi environment, so all 88 rule call sites work unchanged in both modes.
- `.pixi/` and `pixi.lock` gitignored (simflow convention: lock not committed).
- New `unit-tests-pixi` CI job (`prefix-dev/setup-pixi`).
- Docs: pixi documented as the recommended installation; `dataflow install` demoted to the legacy container-site path with a deprecation note; comment in `dataflow-config.yaml` that `execenv:` is optional under pixi.

## Verified locally (pixi 0.75.0)

- `pixi install`: full conda solve succeeds with the exact production pins on first try.
- `pixi run -e test test`: unit suite passes inside the pixi env.
- Inside the env: `snakemake --version` → 9.9.0, `build-tier-dsp` et al. on `PATH`, activation env vars set, and pixi-mode `execenv_pyexe(cfg, "build-tier-dsp")` returns the bare runnable command.

## Follow-ups (out of scope here)

- Rewrite the 88 `execenv_pyexe`/`execenv_prefix` call sites to invoke console scripts directly and delete the execenv machinery once container sites have migrated.
- Decide a `pixi.lock` policy for frozen production cycles (committing the lock at cycle-tag time would make cycles bit-reproducible).

Disclosure per `AI_POLICY.md`: developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)