### PR TITLE
feat: auto-update metadata submodules on workflow start

### DIFF
--- a/dataflow-config.yaml
+++ b/dataflow-config.yaml
@@ -1,4 +1,5 @@
 legend_metadata_version: v1.4.1
+auto_update_metadata: false
 allow_none_par: false
 build_file_dbs: true
 check_log_files: true

--- a/tests/test_metadata_updates.py
+++ b/tests/test_metadata_updates.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from legenddataflow.methods import metadata_updates as mu
+from legenddataflow.methods.metadata_updates import check_metadata_updates
+
+
+def git(repo, *args, check=True):
+    r = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
+    )
+    if check and r.returncode:
+        msg = f"git {' '.join(args)} failed in {repo}: {r.stderr}"
+        raise RuntimeError(msg)
+    return r
+
+
+def init_repo(path: Path):
+    path.mkdir(parents=True, exist_ok=True)
+    git(path, "init", "-q", "-b", "main")
+    git(path, "config", "user.email", "test@example.com")
+    git(path, "config", "user.name", "test")
+    git(path, "config", "commit.gpgsign", "false")
+
+
+def commit_file(repo, rel, content, msg):
+    p = Path(repo) / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", msg)
+
+
+class CapLogger:
+    """Minimal logger capturing .info/.warning lines (with %-formatting)."""
+
+    def __init__(self):
+        self.lines = []
+
+    def info(self, m, *a):
+        self.lines.append("INFO: " + (m % a if a else m))
+
+    def warning(self, m, *a):
+        self.lines.append("WARN: " + (m % a if a else m))
+
+
+def build(base: Path, branch: str = "main"):
+    """Create an ``upstream`` repo (main + optional branch) and a ``work`` clone on ``branch``."""
+    up = base / "upstream"
+    init_repo(up)
+    commit_file(up, "statuses/seed.yaml", "seed: 1\n", "seed")
+    commit_file(up, "raw/validity.yaml", "- valid_from: 0\n", "seed raw")
+    if branch != "main":
+        git(up, "branch", branch)
+    work = base / "work"
+    git(base, "clone", "-q", str(up), str(work))
+    git(work, "config", "user.email", "test@example.com")
+    git(work, "config", "user.name", "test")
+    git(work, "config", "commit.gpgsign", "false")
+    git(work, "checkout", "-q", branch)
+    return up, work
+
+
+def cfg(repo):
+    # Point both metadata targets at the one scratch repo; we assert on the
+    # "legend-datasets" label (its subtree is statuses/, which our commits touch).
+    return {"paths": {"detector_status": str(repo), "par_overwrite": str(repo)}}
+
+
+def test_clean_behind_fast_forwards(tmp_path):
+    up, work = build(tmp_path, "main")
+    commit_file(
+        up, "statuses/new.yaml", "x: 1\n", "upstream advance"
+    )  # main moves ahead
+    log = CapLogger()
+    res = check_metadata_updates(cfg(work), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["updated"] is True
+    assert res["behind_branch"] == 0
+    assert res["dirty"] is False
+
+
+def test_dirty_behind_warns_only(tmp_path):
+    up, work = build(tmp_path, "main")
+    commit_file(up, "statuses/new.yaml", "x: 1\n", "upstream advance")
+    (work / "statuses/seed.yaml").write_text("seed: LOCAL EDIT\n")  # make work dirty
+    log = CapLogger()
+    res = check_metadata_updates(cfg(work), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["updated"] is False
+    assert res["dirty"] is True
+    assert res["behind_branch"] >= 1
+    assert any("DIRTY" in line for line in log.lines)
+
+
+def test_fix_on_main_flagged_not_merged(tmp_path):
+    up, work = build(tmp_path, "p16")  # work tracks period branch p16
+    # a fix lands on upstream main, touching statuses/ -- not on p16
+    git(up, "checkout", "-q", "main")
+    commit_file(
+        up, "statuses/fix.yaml", "V06649M: {processable: false}\n", "fix on main"
+    )
+    log = CapLogger()
+    res = check_metadata_updates(cfg(work), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["branch"] == "p16"
+    assert res["behind_branch"] == 0
+    assert res["behind_main"] >= 1
+    assert res["updated"] is False
+
+
+def test_detached_head_skipped(tmp_path):
+    _up, work = build(tmp_path, "main")
+    head = git(work, "rev-parse", "HEAD").stdout.strip()
+    git(work, "checkout", "-q", head)  # detached HEAD
+    log = CapLogger()
+    res = check_metadata_updates(cfg(work), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["updated"] is False
+    assert res["branch"] in ("", "HEAD")
+    assert any("detached" in line for line in log.lines)
+
+
+def test_offline_fetch_failure_skipped(tmp_path):
+    _up, work = build(tmp_path, "main")
+    git(
+        work, "remote", "set-url", "origin", str(tmp_path / "does-not-exist")
+    )  # break fetch
+    log = CapLogger()
+    res = check_metadata_updates(cfg(work), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["updated"] is False
+    assert any("fetch failed" in line for line in log.lines)
+
+
+def test_missing_repo_skipped(tmp_path):
+    log = CapLogger()
+    res = check_metadata_updates(cfg(tmp_path / "nope"), mode="ff-only", logger=log)[
+        "legend-datasets"
+    ]
+    assert res["updated"] is False
+    assert any("no git repo" in line for line in log.lines)
+
+
+def test_git_helper_never_raises_on_missing_binary(tmp_path, monkeypatch):
+    # A missing git executable must come back as a non-zero CompletedProcess,
+    # not an OSError, so the onstart hook can warn-and-skip.
+    real_run = subprocess.run
+
+    def fake_run(cmd, *a, **k):
+        cmd = ["/nonexistent/git-binary", *cmd[1:]]
+        return real_run(cmd, *a, **k)
+
+    monkeypatch.setattr(mu.subprocess, "run", fake_run)
+    cp = mu._git(tmp_path, "status")
+    assert cp.returncode != 0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -102,6 +102,12 @@ localrules:
 onstart:
     logger.info("INFO: starting workflow")
     paths.link_external_paths(config, logger=logger)
+    # --- optionally refresh the metadata submodules from upstream -----------
+    if config.get("auto_update_metadata", False) and not workflow.touch:
+        from legenddataflow.methods.metadata_updates import check_metadata_updates
+
+        check_metadata_updates(config, mode="ff-only", logger=logger)
+    # ------------------------------------------------------------------------
     # Make sure some packages are initialized before we begin to avoid race conditions
     # https://numba.readthedocs.io/en/stable/developer/caching.html#cache-sharing
     if not workflow.touch:

--- a/workflow/Snakefile-build-raw
+++ b/workflow/Snakefile-build-raw
@@ -68,6 +68,12 @@ include: "rules/blinding_check.smk"
 
 onstart:
     print("INFO: initializing workflow")
+    # --- optionally refresh the metadata submodules from upstream -----------
+    if config.get("auto_update_metadata", False) and not workflow.touch:
+        from legenddataflow.methods.metadata_updates import check_metadata_updates
+
+        check_metadata_updates(config, mode="ff-only")
+    # ------------------------------------------------------------------------
     # Make sure some packages are initialized before we send jobs to avoid race conditions
     if not workflow.touch:
         shell(

--- a/workflow/src/legenddataflow/methods/metadata_updates.py
+++ b/workflow/src/legenddataflow/methods/metadata_updates.py
@@ -1,0 +1,179 @@
+"""Check metadata submodules for upstream updates at workflow start.
+
+Invoked from the ``onstart`` hooks of ``workflow/Snakefile`` and
+``workflow/Snakefile-build-raw`` (guarded by the ``auto_update_metadata`` config
+knob and skipped under ``--touch``). See :func:`check_metadata_updates`.
+
+Production advances each metadata submodule on its own branch, in place
+(legend-datasets -> a period branch e.g. p16/p17; legend-dataflow-overrides ->
+main/new_auto), so a merged fix only reaches a run when that submodule is pulled.
+At workflow start we fetch (read-only) and, per submodule:
+  * fast-forward it iff it is CLEAN and strictly behind its tracked branch;
+  * otherwise only warn -- never clobber the dirty/ahead/detached working trees
+    production keeps (e.g. datasets' local un-pushed edits);
+  * also flag commits on origin/main (touching the relevant subtree) that are not
+    yet on the tracked branch -- e.g. a legend-datasets fix merged to main but not
+    forward-ported onto the period branch.
+
+The only mutation is the opt-in fast-forward merge. ``fetch`` is time-bounded and
+failure-tolerant (a timeout, a missing ``git`` binary, or an offline / no-permission
+run simply skips the check), so the hook never aborts the workflow.
+
+NOTE: metadata is loaded at parse time (top of the Snakefile), before ``onstart``
+runs, so a fast-forward here takes effect on the NEXT run, not the current one.
+For the hourly production this is fine (a fix lands within an hour) and avoids
+changing metadata mid-parse.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _git(repo: Path, *args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    """Run ``git -C <repo> <args>``, capturing output; never raises.
+
+    A non-zero exit, a timeout, or a missing ``git`` executable all come back as
+    a :class:`subprocess.CompletedProcess` with a non-zero ``returncode``, so
+    callers can uniformly warn-and-skip instead of letting the onstart hook abort
+    the workflow.
+    """
+    cmd = ["git", "-C", str(repo), *args]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return subprocess.CompletedProcess(
+            cmd, returncode=1, stdout="", stderr=str(exc)
+        )
+
+
+def _behind(repo: Path, ref: str, subtree: tuple[str, ...] = ()) -> int:
+    """Number of commits in ``HEAD..<ref>`` (optionally restricted to a subtree)."""
+    args = ["rev-list", "--count", f"HEAD..{ref}"]
+    if subtree:
+        args += ["--", *subtree]
+    out = _git(repo, *args).stdout.strip()
+    return int(out) if out.isdigit() else 0
+
+
+def check_metadata_updates(
+    config, *, mode: str = "ff-only", logger=None, notify=None
+) -> dict:
+    """Fetch + report/refresh the metadata submodules. Returns ``{label: info}``.
+
+    Parameters
+    ----------
+    config
+        The workflow config (needs ``config["paths"]["detector_status"]`` and
+        ``config["paths"]["par_overwrite"]``).
+    mode
+        ``"ff-only"`` fast-forwards clean submodules that are strictly behind;
+        ``"warn"`` reports only, never modifies.
+    logger
+        Object with ``.info`` / ``.warning`` (Snakemake's global ``logger``); if
+        ``None``, falls back to this module's :mod:`logging` logger.
+    notify
+        Optional callable ``notify(str)``, e.g. to post to a Slack webhook.
+    """
+    out = logger if logger is not None else log
+    info_ = out.info
+    warn_ = out.warning
+
+    # (label, repo path, subtree that matters for the origin/main divergence check)
+    targets = [
+        (
+            "legend-datasets",
+            config["paths"]["detector_status"],
+            ("statuses", "run_override.yaml", "ignored_daq_cycles.yaml"),
+        ),
+        (
+            "legend-dataflow-overrides/raw",
+            config["paths"]["par_overwrite"],
+            ("raw",),
+        ),
+    ]
+
+    results: dict = {}
+    for label, repo_path, subtree in targets:
+        repo = Path(repo_path)
+        info = {
+            "branch": None,
+            "behind_branch": 0,
+            "behind_main": 0,
+            "dirty": False,
+            "updated": False,
+        }
+
+        if not (repo / ".git").exists():
+            warn_("metadata %s: no git repo at %s -- skipping", label, repo)
+            results[label] = info
+            continue
+
+        branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        info["branch"] = branch
+        info["dirty"] = bool(_git(repo, "status", "--porcelain").stdout.strip())
+
+        # Read-only fetch of the tracked branch (+ main for the divergence check).
+        refs = ([branch] if branch not in ("", "HEAD") else []) + ["main"]
+        if _git(repo, "fetch", "--quiet", "origin", *refs).returncode != 0:
+            warn_(
+                "metadata %s: fetch failed (offline / no permission) -- skipping", label
+            )
+            results[label] = info
+            continue
+
+        if branch in ("", "HEAD"):
+            warn_(
+                "metadata %s: detached HEAD -- cannot track a branch; skipping", label
+            )
+            results[label] = info
+            continue
+
+        info["behind_branch"] = _behind(repo, f"origin/{branch}")
+        info["behind_main"] = (
+            0 if branch == "main" else _behind(repo, "origin/main", subtree)
+        )
+
+        # Fast-forward only if the tree is clean and strictly behind its own branch.
+        if mode == "ff-only" and info["behind_branch"] and not info["dirty"]:
+            if _git(repo, "merge", "--ff-only", f"origin/{branch}").returncode == 0:
+                _git(repo, "submodule", "update", "--init", "--recursive")
+                info["updated"] = True
+                info["behind_branch"] = 0
+            else:
+                warn_(
+                    "metadata %s: cannot fast-forward %s (diverged) -- left as-is",
+                    label,
+                    branch,
+                )
+
+        if info["behind_branch"] or info["behind_main"] or info["dirty"]:
+            msg = (
+                f"metadata {label} on {branch}: {info['behind_branch']} behind origin/{branch}"
+                + (" (fast-forwarded)" if info["updated"] else "")
+                + (
+                    f"; {info['behind_main']} fix commit(s) on origin/main not yet on {branch}"
+                    if info["behind_main"]
+                    else ""
+                )
+                + (" [DIRTY local edits -- not touched]" if info["dirty"] else "")
+            )
+            warn_(msg)
+            if notify:
+                notify(msg)
+        else:
+            info_("metadata %s on %s: up to date", label, branch)
+
+        results[label] = info
+
+    return results


### PR DESCRIPTION
## What

Adds an `onstart` step that keeps the metadata submodules current with upstream.

- **New module** `workflow/src/legenddataflow/methods/metadata_updates.py` —
  `check_metadata_updates()`: a **read-only** (time-bounded, failure-tolerant)
  `git fetch` of each metadata submodule, then per submodule:
  - `ff-only` mode: fast-forward it **iff** the tree is clean and strictly behind
    its tracked branch; otherwise warn only.
  - Never touches dirty / detached / diverged working trees (e.g. the `datasets`
    submodule's local un-pushed edits) — the **only** mutation is a clean
    `merge --ff-only`.
  - Also flags fix commits on `origin/main` not yet forward-ported onto the
    tracked period branch (`behind_main`).
- Wired into both `onstart` hooks (`workflow/Snakefile`, `workflow/Snakefile-build-raw`),
  gated on the new config knob and skipped under `--touch`.
- New `dataflow-config.yaml` knob **`auto-update-metadata: false`** — when `true`,
  the check runs in `ff-only`.

## Notes

- **Applies next cycle, not the current run.** Metadata is loaded at parse time
  (top of the Snakefile) before `onstart`, so a fast-forward is picked up on the
  following run. Fine for the hourly cadence.
- **Never hard-resets.**

## Testing

A standalone harness exercised the clean-behind → fast-forwarded,
dirty-behind → warn-only, on-period-branch-fix-on-main → `behind_main`-flagged,
and offline → skipped-gracefully cases against scratch git repos (no network,
no real metadata); all four passed.

---
🤖 AI-assistance disclosure (per AI_POLICY.md): this change was drafted with
AI assistance (Claude Code) and reviewed by the submitter before submission.
